### PR TITLE
Assert command success by default

### DIFF
--- a/clickhouse_keeper/tests/common.py
+++ b/clickhouse_keeper/tests/common.py
@@ -1067,7 +1067,7 @@ def flask_server(self, server_path, port, protocol, ciphers):
                     for retry in retries(timeout=5, delay=0.5):
                         with retry:
                             r = node.command(
-                                f"ss -ltnup | grep '{port}'", exitcode=None
+                                f"ss -ltnup | grep '{port}'", no_checks=True
                             )
                             assert r.output == "", error(r.output)
 

--- a/clickhouse_keeper/tests/keeper_cluster_tests.py
+++ b/clickhouse_keeper/tests/keeper_cluster_tests.py
@@ -451,7 +451,7 @@ def zookeepers_3(self):
     finally:
         with Finally("I clean up files"):
             clean_coordination_on_all_nodes()
-            self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
+            self.context.cluster.node("clickhouse1").command(f"rm -rf /share/*")
 
 
 @TestScenario
@@ -528,7 +528,7 @@ def standalone_keepers_3(self):
     finally:
         with Finally("I clean up files"):
             clean_coordination_on_all_nodes()
-            self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
+            self.context.cluster.node("clickhouse1").command(f"rm -rf /share/*")
 
 
 @TestScenario
@@ -599,7 +599,7 @@ def standalone_keepers_2(self):
     finally:
         with Finally("I clean up files"):
             clean_coordination_on_all_nodes()
-            self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
+            self.context.cluster.node("clickhouse1").command(f"rm -rf /share/*")
 
 
 @TestScenario
@@ -670,9 +670,7 @@ def standalone_keepers_1(self):
     finally:
         with Finally("I clean up files"):
             clean_coordination_on_all_nodes()
-            for ret in retries(timeout=60, delay=1):
-                with ret:
-                    self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
+            self.context.cluster.node("clickhouse1").command(f"rm -rf /share/*")
 
 
 @TestFeature

--- a/clickhouse_keeper/tests/keeper_cluster_tests.py
+++ b/clickhouse_keeper/tests/keeper_cluster_tests.py
@@ -670,7 +670,9 @@ def standalone_keepers_1(self):
     finally:
         with Finally("I clean up files"):
             clean_coordination_on_all_nodes()
-            self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
+            for retry in retries(timeout=60, delay=1):
+                with retry:
+                    self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
 
 
 @TestFeature

--- a/clickhouse_keeper/tests/keeper_cluster_tests.py
+++ b/clickhouse_keeper/tests/keeper_cluster_tests.py
@@ -670,8 +670,8 @@ def standalone_keepers_1(self):
     finally:
         with Finally("I clean up files"):
             clean_coordination_on_all_nodes()
-            for retry in retries(timeout=60, delay=1):
-                with retry:
+            for ret in retries(timeout=60, delay=1):
+                with ret:
                     self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
 
 

--- a/clickhouse_keeper/tests/migration.py
+++ b/clickhouse_keeper/tests/migration.py
@@ -170,9 +170,7 @@ def migrate_from_zookeeper(self, use_standalone_keeper_server):
     finally:
         with Finally("I clean up"):
             with By("Clear Zookeeper meta information", flags=TE):
-                self.context.cluster.node("clickhouse1").command(
-                    f"rm -rf /share/*"
-                )
+                self.context.cluster.node("clickhouse1").command(f"rm -rf /share/*")
                 clean_coordination_on_all_nodes()
 
             with By("I restart ZooKeepers back up", flags=TE):

--- a/clickhouse_keeper/tests/migration.py
+++ b/clickhouse_keeper/tests/migration.py
@@ -170,11 +170,9 @@ def migrate_from_zookeeper(self, use_standalone_keeper_server):
     finally:
         with Finally("I clean up"):
             with By("Clear Zookeeper meta information", flags=TE):
-                for retry in retries(timeout=60, delay=1):
-                    with retry:
-                        self.context.cluster.node("clickhouse1").command(
-                            f"rm -rf /share/"
-                        )
+                self.context.cluster.node("clickhouse1").command(
+                    f"rm -rf /share/*"
+                )
                 clean_coordination_on_all_nodes()
 
             with By("I restart ZooKeepers back up", flags=TE):
@@ -211,7 +209,7 @@ def migrate_from_zookeeper(self, use_standalone_keeper_server):
                 stop_all_zookeepers()
 
             with By("Clear Zookeeper meta information", flags=TE):
-                self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
+                self.context.cluster.node("clickhouse1").command(f"rm -rf /share/*")
                 clean_coordination_on_all_nodes()
 
             with By("I restart ZooKeepers back up", flags=TE):

--- a/clickhouse_keeper/tests/migration.py
+++ b/clickhouse_keeper/tests/migration.py
@@ -170,7 +170,9 @@ def migrate_from_zookeeper(self, use_standalone_keeper_server):
     finally:
         with Finally("I clean up"):
             with By("Clear Zookeeper meta information", flags=TE):
-                self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
+                for retry in retries(timeout=60, delay=1):
+                    with retry:
+                        self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
                 clean_coordination_on_all_nodes()
 
             with By("I restart ZooKeepers back up", flags=TE):

--- a/clickhouse_keeper/tests/migration.py
+++ b/clickhouse_keeper/tests/migration.py
@@ -172,7 +172,9 @@ def migrate_from_zookeeper(self, use_standalone_keeper_server):
             with By("Clear Zookeeper meta information", flags=TE):
                 for retry in retries(timeout=60, delay=1):
                     with retry:
-                        self.context.cluster.node("clickhouse1").command(f"rm -rf /share/")
+                        self.context.cluster.node("clickhouse1").command(
+                            f"rm -rf /share/"
+                        )
                 clean_coordination_on_all_nodes()
 
             with By("I restart ZooKeepers back up", flags=TE):

--- a/dns/tests/ipv6.py
+++ b/dns/tests/ipv6.py
@@ -38,7 +38,9 @@ def feature(self):
     def setup_dns_server(ip):
         domains_string = "test3.example.com test2.example.com test1.example.com"
         example_file_path = f"regression/dns/tests/lookup/example.com"
-        cluster.command(None, f"echo '{ip} {domains_string}' > {example_file_path}", exitcode=None)
+        cluster.command(
+            None, f"echo '{ip} {domains_string}' > {example_file_path}", exitcode=None
+        )
 
     def setup_ch_server(dns_server_ip):
         cluster.node("clickhouse1").command(

--- a/dns/tests/ipv6.py
+++ b/dns/tests/ipv6.py
@@ -38,7 +38,7 @@ def feature(self):
     def setup_dns_server(ip):
         domains_string = "test3.example.com test2.example.com test1.example.com"
         example_file_path = f"regression/dns/tests/lookup/example.com"
-        cluster.command(None, f"echo '{ip} {domains_string}' > {example_file_path}")
+        cluster.command(None, f"echo '{ip} {domains_string}' > {example_file_path}", exitcode=None)
 
     def setup_ch_server(dns_server_ip):
         cluster.node("clickhouse1").command(

--- a/dns/tests/ipv6.py
+++ b/dns/tests/ipv6.py
@@ -39,7 +39,7 @@ def feature(self):
         domains_string = "test3.example.com test2.example.com test1.example.com"
         example_file_path = f"regression/dns/tests/lookup/example.com"
         cluster.command(
-            None, f"echo '{ip} {domains_string}' > {example_file_path}", exitcode=None
+            None, f"echo '{ip} {domains_string}' > {example_file_path}", no_checks=True
         )
 
     def setup_ch_server(dns_server_ip):

--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -342,7 +342,7 @@ class ClickHouseNode(Node):
         """Return ClickHouse server pid if present
         otherwise return None.
         """
-        if self.command("ls /tmp/clickhouse-server.pid").exitcode == 0:
+        if self.command("ls /tmp/clickhouse-server.pid", exitcode=None).exitcode == 0:
             return self.command("cat /tmp/clickhouse-server.pid").output.strip()
         return None
 
@@ -1406,7 +1406,7 @@ class Cluster(object):
         :param command: command
         :param message: expected message that should be in the output, default: None
         :param messages: expected messages that should be in the output, default: None
-        :param exitcode: expected exitcode, default: None
+        :param exitcode: expected exitcode, set to None to ignore, default: 0
         :param steps: don't break command into steps, default: True
         """
         with By(

--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -1392,7 +1392,7 @@ class Cluster(object):
         command,
         message=None,
         messages=None,
-        exitcode=None,
+        exitcode=0,
         steps=True,
         bash=None,
         no_checks=False,

--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -342,7 +342,7 @@ class ClickHouseNode(Node):
         """Return ClickHouse server pid if present
         otherwise return None.
         """
-        if self.command("ls /tmp/clickhouse-server.pid", exitcode=None).exitcode == 0:
+        if self.command("ls /tmp/clickhouse-server.pid", no_checks=True).exitcode == 0:
             return self.command("cat /tmp/clickhouse-server.pid").output.strip()
         return None
 
@@ -1298,7 +1298,7 @@ class Cluster(object):
                         cmd = self.command(
                             None,
                             f"set -o pipefail && {self.docker_compose} pull 2>&1 | tee",
-                            exitcode=None,
+                            no_checks=True,
                             timeout=timeout,
                         )
                         if cmd.exitcode != 0:
@@ -1313,7 +1313,7 @@ class Cluster(object):
                         cmd = self.command(
                             None,
                             f"set -o pipefail && {self.docker_compose} down 2>&1 | tee",
-                            exitcode=None,
+                            no_checks=True,
                             timeout=timeout,
                         )
                         if cmd.exitcode != 0:
@@ -1406,7 +1406,8 @@ class Cluster(object):
         :param command: command
         :param message: expected message that should be in the output, default: None
         :param messages: expected messages that should be in the output, default: None
-        :param exitcode: expected exitcode, set to None to ignore, default: 0
+        :param exitcode: expected exitcode, use no_checks or set to None to ignore, default: 0
+        :param no_checks: skip exitcode and message checks, default: False
         :param steps: don't break command into steps, default: True
         """
         with By(

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -559,7 +559,7 @@ def add_group_on_node(self, node=None, groupname="clickhouse"):
         node.command(f"groupadd {groupname}", exitcode=0)
         yield
     finally:
-        node.command(f"delgroup {groupname}")
+        node.command(f"delgroup {groupname}", exitcode=None)
 
 
 @TestStep(Given)

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -559,7 +559,7 @@ def add_group_on_node(self, node=None, groupname="clickhouse"):
         node.command(f"groupadd {groupname}", exitcode=0)
         yield
     finally:
-        node.command(f"delgroup clickhouse", exitcode=None)
+        node.command(f"delgroup {groupname}")
 
 
 @TestStep(Given)

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -267,7 +267,7 @@ def add_invalid_config(
             started = time.time()
             command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False, exitcode=None).exitcode
+                exitcode = node.command(command, steps=False, no_checks=True).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)
@@ -326,7 +326,7 @@ def add_invalid_config(
         started = time.time()
         command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
         while time.time() - started < timeout:
-            exitcode = node.command(command, steps=False, exitcode=None).exitcode
+            exitcode = node.command(command, steps=False, no_checks=True).exitcode
             if exitcode == 0:
                 break
             time.sleep(1)
@@ -360,7 +360,7 @@ def add_config(
         command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
 
         while time.time() - started < timeout:
-            exitcode = node.command(command, steps=False, exitcode=None).exitcode
+            exitcode = node.command(command, steps=False, no_checks=True).exitcode
             if after_removal:
                 if exitcode == 1:
                     break
@@ -559,7 +559,7 @@ def add_group_on_node(self, node=None, groupname="clickhouse"):
         node.command(f"groupadd {groupname}", exitcode=0)
         yield
     finally:
-        node.command(f"delgroup {groupname}", exitcode=None)
+        node.command(f"delgroup {groupname}", no_checks=True)
 
 
 @TestStep(Given)

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -267,7 +267,7 @@ def add_invalid_config(
             started = time.time()
             command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False).exitcode
+                exitcode = node.command(command, steps=False, exitcode=0).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)
@@ -326,7 +326,7 @@ def add_invalid_config(
         started = time.time()
         command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
         while time.time() - started < timeout:
-            exitcode = node.command(command, steps=False).exitcode
+            exitcode = node.command(command, steps=False, exitcode=None).exitcode
             if exitcode == 0:
                 break
             time.sleep(1)

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -559,7 +559,7 @@ def add_group_on_node(self, node=None, groupname="clickhouse"):
         node.command(f"groupadd {groupname}", exitcode=0)
         yield
     finally:
-        node.command(f"delgroup clickhouse")
+        node.command(f"delgroup clickhouse", exitcode=None)
 
 
 @TestStep(Given)

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -360,7 +360,7 @@ def add_config(
         command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
 
         while time.time() - started < timeout:
-            exitcode = node.command(command, steps=False).exitcode
+            exitcode = node.command(command, steps=False, exitcode=None).exitcode
             if after_removal:
                 if exitcode == 1:
                     break

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -267,7 +267,7 @@ def add_invalid_config(
             started = time.time()
             command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False, exitcode=0).exitcode
+                exitcode = node.command(command, steps=False, exitcode=None).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -16,14 +16,14 @@ def delete_any_old_topic_and_consumer_group(
             f"kafka-topics "
             f"--bootstrap-server {bootstrap_server} --delete --topic {topic}"
         )
-        node.command(command)
+        node.command(command, exitcode=None)
 
     with By("deleting consumer group"):
         command = (
             f"kafka-consumer-groups "
             f"--bootstrap-server {bootstrap_server} --delete --group {consumer_group}"
         )
-        node.command(command)
+        node.command(command, exitcode=None)
 
 
 @TestStep(Given)

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -16,14 +16,14 @@ def delete_any_old_topic_and_consumer_group(
             f"kafka-topics "
             f"--bootstrap-server {bootstrap_server} --delete --topic {topic}"
         )
-        node.command(command, exitcode=None)
+        node.command(command, no_checks=True)
 
     with By("deleting consumer group"):
         command = (
             f"kafka-consumer-groups "
             f"--bootstrap-server {bootstrap_server} --delete --group {consumer_group}"
         )
-        node.command(command, exitcode=None)
+        node.command(command, no_checks=True)
 
 
 @TestStep(Given)

--- a/kafka/tests/non_replicated.py
+++ b/kafka/tests/non_replicated.py
@@ -50,7 +50,7 @@ def scenario(self):
                 f"{cluster.docker_compose} exec -T kafka1 kafka-console-producer "
                 f"--broker-list kafka1:9092,kafka2:9092,kafka3:9092 --topic {topic} > /dev/null"
             )
-            cluster.command(None, command, exitcode=None)
+            cluster.command(None, command, no_checks=True)
 
         with And("I create destination tables pipeline"):
             sql = f"""

--- a/kerberos/tests/common.py
+++ b/kerberos/tests/common.py
@@ -54,12 +54,12 @@ def test_select_query(node, krb_auth=True, req="SELECT currentUser()"):
 def kinit_no_keytab(self, node, principal="kerberos_user", lifetime_option="-l 10:00"):
     """Helper for obtaining Kerberos ticket for client"""
     try:
-        node.command("echo pwd | kinit admin/admin")
-        node.command(f'kadmin -w pwd -q "add_principal -pw pwd {principal}"')
-        node.command(f"echo pwd | kinit {lifetime_option} {principal}")
+        node.command("echo pwd | kinit admin/admin", exitcode=None)
+        node.command(f'kadmin -w pwd -q "add_principal -pw pwd {principal}"', exitcode=None)
+        node.command(f"echo pwd | kinit {lifetime_option} {principal}", exitcode=None)
         yield
     finally:
-        node.command("kdestroy")
+        node.command("kdestroy", exitcode=None)
 
 
 @TestStep(Given)

--- a/kerberos/tests/common.py
+++ b/kerberos/tests/common.py
@@ -71,11 +71,11 @@ def create_server_principal(self, node):
         node.command("echo pwd | kinit admin/admin", no_checks=True)
         node.command(
             f'kadmin -w pwd -q "add_principal -randkey HTTP/{self.context.env}-{node.name}-1.krbnet"',
-            no_checks=True
+            no_checks=True,
         )
         node.command(
             f'kadmin -w pwd -q "ktadd -k /etc/krb5.keytab HTTP/{self.context.env}-{node.name}-1.krbnet"',
-            no_checks=True
+            no_checks=True,
         )
         yield
     finally:

--- a/kerberos/tests/common.py
+++ b/kerberos/tests/common.py
@@ -212,7 +212,7 @@ def check_wrong_config(
             started = time.time()
             command = f"cat /var/lib/clickhouse/preprocessed_configs/{preprocessed_name} | grep {uid} > /dev/null"
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False).exitcode
+                exitcode = node.command(command, steps=False, exitcode=None).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)
@@ -254,7 +254,7 @@ def check_wrong_config(
             started = time.time()
             command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{log_error}"'
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False).exitcode
+                exitcode = node.command(command, steps=False, exitcode=None).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)

--- a/kerberos/tests/common.py
+++ b/kerberos/tests/common.py
@@ -55,7 +55,9 @@ def kinit_no_keytab(self, node, principal="kerberos_user", lifetime_option="-l 1
     """Helper for obtaining Kerberos ticket for client"""
     try:
         node.command("echo pwd | kinit admin/admin", exitcode=None)
-        node.command(f'kadmin -w pwd -q "add_principal -pw pwd {principal}"', exitcode=None)
+        node.command(
+            f'kadmin -w pwd -q "add_principal -pw pwd {principal}"', exitcode=None
+        )
         node.command(f"echo pwd | kinit {lifetime_option} {principal}", exitcode=None)
         yield
     finally:
@@ -66,7 +68,7 @@ def kinit_no_keytab(self, node, principal="kerberos_user", lifetime_option="-l 1
 def create_server_principal(self, node):
     """Helper for obtaining Kerberos ticket for server"""
     try:
-        node.command("echo pwd | kinit admin/admin")
+        node.command("echo pwd | kinit admin/admin", exitcode=None)
         node.command(
             f'kadmin -w pwd -q "add_principal -randkey HTTP/{self.context.env}-{node.name}-1.krbnet"'
         )
@@ -75,8 +77,8 @@ def create_server_principal(self, node):
         )
         yield
     finally:
-        node.command("kdestroy")
-        node.command("rm /etc/krb5.keytab")
+        node.command("kdestroy", exitcode=None)
+        node.command("rm /etc/krb5.keytab", exitcode=None)
 
 
 @TestStep(Given)

--- a/kerberos/tests/common.py
+++ b/kerberos/tests/common.py
@@ -54,31 +54,33 @@ def test_select_query(node, krb_auth=True, req="SELECT currentUser()"):
 def kinit_no_keytab(self, node, principal="kerberos_user", lifetime_option="-l 10:00"):
     """Helper for obtaining Kerberos ticket for client"""
     try:
-        node.command("echo pwd | kinit admin/admin", exitcode=None)
+        node.command("echo pwd | kinit admin/admin", no_checks=True)
         node.command(
-            f'kadmin -w pwd -q "add_principal -pw pwd {principal}"', exitcode=None
+            f'kadmin -w pwd -q "add_principal -pw pwd {principal}"', no_checks=True
         )
-        node.command(f"echo pwd | kinit {lifetime_option} {principal}", exitcode=None)
+        node.command(f"echo pwd | kinit {lifetime_option} {principal}", no_checks=True)
         yield
     finally:
-        node.command("kdestroy", exitcode=None)
+        node.command("kdestroy", no_checks=True)
 
 
 @TestStep(Given)
 def create_server_principal(self, node):
     """Helper for obtaining Kerberos ticket for server"""
     try:
-        node.command("echo pwd | kinit admin/admin", exitcode=None)
+        node.command("echo pwd | kinit admin/admin", no_checks=True)
         node.command(
-            f'kadmin -w pwd -q "add_principal -randkey HTTP/{self.context.env}-{node.name}-1.krbnet"'
+            f'kadmin -w pwd -q "add_principal -randkey HTTP/{self.context.env}-{node.name}-1.krbnet"',
+            no_checks=True
         )
         node.command(
-            f'kadmin -w pwd -q "ktadd -k /etc/krb5.keytab HTTP/{self.context.env}-{node.name}-1.krbnet"'
+            f'kadmin -w pwd -q "ktadd -k /etc/krb5.keytab HTTP/{self.context.env}-{node.name}-1.krbnet"',
+            no_checks=True
         )
         yield
     finally:
-        node.command("kdestroy", exitcode=None)
-        node.command("rm /etc/krb5.keytab", exitcode=None)
+        node.command("kdestroy", no_checks=True)
+        node.command("rm /etc/krb5.keytab", no_checks=True)
 
 
 @TestStep(Given)
@@ -212,7 +214,7 @@ def check_wrong_config(
             started = time.time()
             command = f"cat /var/lib/clickhouse/preprocessed_configs/{preprocessed_name} | grep {uid} > /dev/null"
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False, exitcode=None).exitcode
+                exitcode = node.command(command, steps=False, no_checks=True).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)
@@ -254,7 +256,7 @@ def check_wrong_config(
             started = time.time()
             command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{log_error}"'
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False, exitcode=None).exitcode
+                exitcode = node.command(command, steps=False, no_checks=True).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)

--- a/kerberos/tests/generic.py
+++ b/kerberos/tests/generic.py
@@ -13,7 +13,7 @@ def ping(self):
 
     for i in range(3):
         with When(f"curl ch_{i} kerberos"):
-            r = ch_nodes[i].command(f"curl kerberos -c 1", exitcode=None)
+            r = ch_nodes[i].command(f"curl kerberos -c 1", no_checks=True)
         with Then(f"return code should be 0"):
             assert r.exitcode == 7, error()
 

--- a/kerberos/tests/generic.py
+++ b/kerberos/tests/generic.py
@@ -13,7 +13,7 @@ def ping(self):
 
     for i in range(3):
         with When(f"curl ch_{i} kerberos"):
-            r = ch_nodes[i].command(f"curl kerberos -c 1")
+            r = ch_nodes[i].command(f"curl kerberos -c 1", exitcode=None)
         with Then(f"return code should be 0"):
             assert r.exitcode == 7, error()
 

--- a/ldap/authentication/tests/common.py
+++ b/ldap/authentication/tests/common.py
@@ -215,7 +215,7 @@ def invalid_server_config(servers, message=None, tail=30, timeout=300):
             started = time.time()
             command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False).exitcode
+                exitcode = node.command(command, steps=False, exitcode=None).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)
@@ -246,7 +246,9 @@ def invalid_user_config(servers, config, message=None, tail=30, timeout=300):
                 started = time.time()
                 command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
                 while time.time() - started < timeout:
-                    exitcode = node.command(command, steps=False).exitcode
+                    exitcode = node.command(
+                        command, steps=False, exitcode=None
+                    ).exitcode
                     if exitcode == 0:
                         break
                     time.sleep(1)
@@ -309,7 +311,8 @@ def add_user_to_ldap(
     ldif = "\n".join(lines)
 
     r = node.command(
-        f'echo -e "{ldif}" | ldapadd -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin'
+        f'echo -e "{ldif}" | ldapadd -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
+        exitcode=None,
     )
     assert r.exitcode == 0, error()
 
@@ -321,7 +324,8 @@ def delete_user_from_ldap(user, node=None, exitcode=0):
     if node is None:
         node = current().context.ldap_node
     r = node.command(
-        f"ldapdelete -x -H ldap://localhost -D \"cn=admin,dc=company,dc=com\" -w admin \"{user['dn']}\""
+        f"ldapdelete -x -H ldap://localhost -D \"cn=admin,dc=company,dc=com\" -w admin \"{user['dn']}\"",
+        exitcode=None,
     )
     if exitcode is not None:
         assert r.exitcode == exitcode, error()
@@ -340,7 +344,8 @@ def change_user_password_in_ldap(user, new_password, node=None, exitcode=0):
     )
 
     r = node.command(
-        f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin'
+        f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
+        exitcode=None,
     )
 
     if exitcode is not None:
@@ -364,7 +369,8 @@ def change_user_cn_in_ldap(user, new_cn, node=None, exitcode=0):
     )
 
     r = node.command(
-        f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin'
+        f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
+        exitcode=None,
     )
 
     if exitcode is not None:

--- a/ldap/authentication/tests/common.py
+++ b/ldap/authentication/tests/common.py
@@ -215,7 +215,7 @@ def invalid_server_config(servers, message=None, tail=30, timeout=300):
             started = time.time()
             command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False, exitcode=None).exitcode
+                exitcode = node.command(command, steps=False, no_checks=True).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)
@@ -247,7 +247,7 @@ def invalid_user_config(servers, config, message=None, tail=30, timeout=300):
                 command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
                 while time.time() - started < timeout:
                     exitcode = node.command(
-                        command, steps=False, exitcode=None
+                        command, steps=False, no_checks=True
                     ).exitcode
                     if exitcode == 0:
                         break
@@ -312,7 +312,7 @@ def add_user_to_ldap(
 
     r = node.command(
         f'echo -e "{ldif}" | ldapadd -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
-        exitcode=None,
+        no_checks=True,
     )
     assert r.exitcode == 0, error()
 
@@ -325,7 +325,7 @@ def delete_user_from_ldap(user, node=None, exitcode=0):
         node = current().context.ldap_node
     r = node.command(
         f"ldapdelete -x -H ldap://localhost -D \"cn=admin,dc=company,dc=com\" -w admin \"{user['dn']}\"",
-        exitcode=None,
+        no_checks=True,
     )
     if exitcode is not None:
         assert r.exitcode == exitcode, error()
@@ -345,7 +345,7 @@ def change_user_password_in_ldap(user, new_password, node=None, exitcode=0):
 
     r = node.command(
         f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
-        exitcode=None,
+        no_checks=True,
     )
 
     if exitcode is not None:
@@ -370,7 +370,7 @@ def change_user_cn_in_ldap(user, new_cn, node=None, exitcode=0):
 
     r = node.command(
         f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
-        exitcode=None,
+        no_checks=True,
     )
 
     if exitcode is not None:

--- a/ldap/authentication/tests/sanity.py
+++ b/ldap/authentication/tests/sanity.py
@@ -15,7 +15,7 @@ def scenario(self, server="openldap1"):
     with When("I search LDAP database"):
         r = self.context.ldap_node.command(
             'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin',
-            exitcode=None,
+            no_checks=True,
         )
         assert r.exitcode == 0, error()
 
@@ -28,7 +28,7 @@ def scenario(self, server="openldap1"):
     with And("I search LDAP database again"):
         r = self.context.ldap_node.command(
             'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin',
-            exitcode=None,
+            no_checks=True,
         )
         assert r.exitcode == 0, error()
 
@@ -41,7 +41,7 @@ def scenario(self, server="openldap1"):
     with And("I search LDAP database again"):
         r = self.context.ldap_node.command(
             'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin',
-            exitcode=None,
+            no_checks=True,
         )
         assert r.exitcode == 0, error()
 

--- a/ldap/authentication/tests/sanity.py
+++ b/ldap/authentication/tests/sanity.py
@@ -14,7 +14,8 @@ def scenario(self, server="openldap1"):
 
     with When("I search LDAP database"):
         r = self.context.ldap_node.command(
-            'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin'
+            'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin',
+            exitcode=None,
         )
         assert r.exitcode == 0, error()
 
@@ -26,7 +27,8 @@ def scenario(self, server="openldap1"):
 
     with And("I search LDAP database again"):
         r = self.context.ldap_node.command(
-            'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin'
+            'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin',
+            exitcode=None,
         )
         assert r.exitcode == 0, error()
 
@@ -38,7 +40,8 @@ def scenario(self, server="openldap1"):
 
     with And("I search LDAP database again"):
         r = self.context.ldap_node.command(
-            'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin'
+            'ldapsearch -x -H ldap://localhost -b "dc=company,dc=com" -D "cn=admin,dc=company,dc=com" -w admin',
+            exitcode=None,
         )
         assert r.exitcode == 0, error()
 

--- a/ldap/external_user_directory/tests/common.py
+++ b/ldap/external_user_directory/tests/common.py
@@ -89,7 +89,7 @@ def verify_ldap_user_exists(server, username, password):
     with By("searching LDAP database"):
         ldap_node = current().context.cluster.node(server)
         r = ldap_node.command(
-            f"ldapwhoami -H ldap://localhost -D 'cn={user_name},ou=users,dc=company,dc=com' -w {password}"
+            f"ldapwhoami -H ldap://localhost -D 'cn={username},ou=users,dc=company,dc=com' -w {password}"
         )
         assert r.exitcode == 0, error()
 
@@ -191,7 +191,7 @@ def invalid_ldap_external_user_directory_config(
             started = time.time()
             command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False).exitcode
+                exitcode = node.command(command, steps=False, exitcode=None).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)
@@ -222,7 +222,7 @@ def invalid_ldap_external_user_directory_config(
         started = time.time()
         command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
         while time.time() - started < timeout:
-            exitcode = node.command(command, steps=False).exitcode
+            exitcode = node.command(command, steps=False, exitcode=None).exitcode
             if exitcode == 0:
                 break
             time.sleep(1)

--- a/ldap/external_user_directory/tests/common.py
+++ b/ldap/external_user_directory/tests/common.py
@@ -191,7 +191,7 @@ def invalid_ldap_external_user_directory_config(
             started = time.time()
             command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False, exitcode=None).exitcode
+                exitcode = node.command(command, steps=False, no_checks=True).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)
@@ -222,7 +222,7 @@ def invalid_ldap_external_user_directory_config(
         started = time.time()
         command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
         while time.time() - started < timeout:
-            exitcode = node.command(command, steps=False, exitcode=None).exitcode
+            exitcode = node.command(command, steps=False, no_checks=True).exitcode
             if exitcode == 0:
                 break
             time.sleep(1)

--- a/ldap/external_user_directory/tests/server_config.py
+++ b/ldap/external_user_directory/tests/server_config.py
@@ -104,7 +104,7 @@ def missing_host(self, tail=30, timeout=300):
             started = time.time()
             command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False).exitcode
+                exitcode = node.command(command, steps=False, exitcode=None).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)

--- a/ldap/external_user_directory/tests/server_config.py
+++ b/ldap/external_user_directory/tests/server_config.py
@@ -104,7 +104,7 @@ def missing_host(self, tail=30, timeout=300):
             started = time.time()
             command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
             while time.time() - started < timeout:
-                exitcode = node.command(command, steps=False, exitcode=None).exitcode
+                exitcode = node.command(command, steps=False, no_checks=True).exitcode
                 if exitcode == 0:
                     break
                 time.sleep(1)

--- a/ldap/role_mapping/tests/common.py
+++ b/ldap/role_mapping/tests/common.py
@@ -172,7 +172,8 @@ def add_group_to_ldap(cn, gidnumber=None, node=None, _gidnumber=[600], exitcode=
     ldif = "\n".join(lines)
 
     r = node.command(
-        f'echo -e "{ldif}" | ldapadd -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin'
+        f'echo -e "{ldif}" | ldapadd -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
+        exitcode=None,
     )
 
     if exitcode is not None:
@@ -188,7 +189,8 @@ def delete_group_from_ldap(group, node=None, exitcode=0):
 
     with By(f"deleting group {group['dn']}"):
         r = node.command(
-            f"ldapdelete -x -H ldap://localhost -D \"cn=admin,dc=company,dc=com\" -w admin \"{group['dn']}\""
+            f"ldapdelete -x -H ldap://localhost -D \"cn=admin,dc=company,dc=com\" -w admin \"{group['dn']}\"",
+            exitcode=None,
         )
 
     if exitcode is not None:
@@ -210,7 +212,9 @@ def fix_ldap_permissions(node=None, exitcode=0):
         'olcAccess: to * by self write by dn=\\"cn=admin,dc=company,dc=com\\" read by users read by * none'
     )
 
-    r = node.command(f'echo -e "{ldif}" | ldapmodify -Y EXTERNAL -Q -H ldapi:///')
+    r = node.command(
+        f'echo -e "{ldif}" | ldapmodify -Y EXTERNAL -Q -H ldapi:///', exitcode=None
+    )
 
     if exitcode is not None:
         assert r.exitcode == exitcode, error()
@@ -230,7 +234,8 @@ def add_user_to_group_in_ldap(user, group, node=None, exitcode=0):
 
     with By(f"adding user {user['dn']} to group {group['dn']}"):
         r = node.command(
-            f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin'
+            f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
+            exitcode=None,
         )
 
     if exitcode is not None:
@@ -251,7 +256,8 @@ def delete_user_from_group_in_ldap(user, group, node=None, exitcode=0):
 
     with By(f"deleting user {user['dn']} from group {group['dn']}"):
         r = node.command(
-            f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin'
+            f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
+            exitcode=None,
         )
 
     if exitcode is not None:

--- a/ldap/role_mapping/tests/common.py
+++ b/ldap/role_mapping/tests/common.py
@@ -173,7 +173,7 @@ def add_group_to_ldap(cn, gidnumber=None, node=None, _gidnumber=[600], exitcode=
 
     r = node.command(
         f'echo -e "{ldif}" | ldapadd -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
-        exitcode=None,
+        no_checks=True,
     )
 
     if exitcode is not None:
@@ -190,7 +190,7 @@ def delete_group_from_ldap(group, node=None, exitcode=0):
     with By(f"deleting group {group['dn']}"):
         r = node.command(
             f"ldapdelete -x -H ldap://localhost -D \"cn=admin,dc=company,dc=com\" -w admin \"{group['dn']}\"",
-            exitcode=None,
+            no_checks=True,
         )
 
     if exitcode is not None:
@@ -213,7 +213,7 @@ def fix_ldap_permissions(node=None, exitcode=0):
     )
 
     r = node.command(
-        f'echo -e "{ldif}" | ldapmodify -Y EXTERNAL -Q -H ldapi:///', exitcode=None
+        f'echo -e "{ldif}" | ldapmodify -Y EXTERNAL -Q -H ldapi:///', no_checks=True
     )
 
     if exitcode is not None:
@@ -235,7 +235,7 @@ def add_user_to_group_in_ldap(user, group, node=None, exitcode=0):
     with By(f"adding user {user['dn']} to group {group['dn']}"):
         r = node.command(
             f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
-            exitcode=None,
+            no_checks=True,
         )
 
     if exitcode is not None:
@@ -257,7 +257,7 @@ def delete_user_from_group_in_ldap(user, group, node=None, exitcode=0):
     with By(f"deleting user {user['dn']} from group {group['dn']}"):
         r = node.command(
             f'echo -e "{ldif}" | ldapmodify -x -H ldap://localhost -D "cn=admin,dc=company,dc=com" -w admin',
-            exitcode=None,
+            no_checks=True,
         )
 
     if exitcode is not None:

--- a/parquet/tests/common.py
+++ b/parquet/tests/common.py
@@ -137,7 +137,7 @@ def copy_file_to_host(self, src_node, src_path, host_filename):
             ).output
 
         with And("copying the file from the node to the host"):
-            self.context.cluster.command(None, f"mkdir /tmp/test_files")
+            self.context.cluster.command(None, f"mkdir /tmp/test_files", exitcode=None)
             self.context.cluster.command(
                 None, f"docker cp {x}:{src_path} /tmp/test_files/{host_filename}"
             )

--- a/parquet/tests/common.py
+++ b/parquet/tests/common.py
@@ -137,7 +137,7 @@ def copy_file_to_host(self, src_node, src_path, host_filename):
             ).output
 
         with And("copying the file from the node to the host"):
-            self.context.cluster.command(None, f"mkdir /tmp/test_files", exitcode=None)
+            self.context.cluster.command(None, f"mkdir /tmp/test_files", no_checks=True)
             self.context.cluster.command(
                 None, f"docker cp {x}:{src_path} /tmp/test_files/{host_filename}"
             )

--- a/s3/tests/common.py
+++ b/s3/tests/common.py
@@ -38,7 +38,7 @@ def add_config(
         command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
 
         while time.time() - started < timeout:
-            exitcode = node.command(command, steps=False, exitcode=None).exitcode
+            exitcode = node.command(command, steps=False, no_checks=True).exitcode
             if after_removal:
                 if exitcode == 1:
                     break
@@ -714,7 +714,7 @@ def run_query(instance, query, stdin=None, settings=None):
         result = instance.command(
             f'echo -e "{stdin}" | clickhouse client --query="{query}"',
             steps=False,
-            exitcode=None,
+            no_checks=True,
         )
     else:
         result = instance.query(

--- a/s3/tests/common.py
+++ b/s3/tests/common.py
@@ -38,7 +38,7 @@ def add_config(
         command = f"cat /var/lib/clickhouse/preprocessed_configs/{config.preprocessed_name} | grep {config.uid}{' > /dev/null' if not settings.debug else ''}"
 
         while time.time() - started < timeout:
-            exitcode = node.command(command, steps=False).exitcode
+            exitcode = node.command(command, steps=False, exitcode=None).exitcode
             if after_removal:
                 if exitcode == 1:
                     break

--- a/s3/tests/common.py
+++ b/s3/tests/common.py
@@ -712,7 +712,9 @@ def run_query(instance, query, stdin=None, settings=None):
         stdin_file.seek(0)
 
         result = instance.command(
-            f'echo -e "{stdin}" | clickhouse client --query="{query}"', steps=False
+            f'echo -e "{stdin}" | clickhouse client --query="{query}"',
+            steps=False,
+            exitcode=None,
         )
     else:
         result = instance.query(

--- a/s3/tests/common.py
+++ b/s3/tests/common.py
@@ -643,11 +643,14 @@ def get_random_string(cluster, length, steps=True, *args, **kwargs):
             None,
             f"cat /dev/urandom | tr -dc 'A-Za-z0-9#$&()*+,-./:;<=>?@[\]^_~' | head -c {length} > {fd.name}",
             steps=steps,
+            no_checks=True,
             *args,
             **kwargs,
         )
         fd.seek(0)
-        return fd.read()
+        random_string = fd.read()
+        assert len(random_string) == length
+        return random_string
 
 
 @TestStep(When)

--- a/session_timezone/tests/clickhouse_local.py
+++ b/session_timezone/tests/clickhouse_local.py
@@ -13,6 +13,7 @@ def bad_arguments(self):
         clickhouse_local(
             query="select timezoneOf(now()) SETTINGS session_timezone = 'fasdf' format TSV;",
             message="Exception: Invalid time zone",
+            exitcode=36,
         )
 
 

--- a/session_timezone/tests/steps.py
+++ b/session_timezone/tests/steps.py
@@ -4,7 +4,12 @@ from helpers.common import getuid
 
 @TestStep
 def clickhouse_local(
-    self, query="select timezone()", node=None, timezone="UTC", message=""
+    self,
+    query="select timezone()",
+    node=None,
+    timezone="UTC",
+    message="",
+    exitcode=0,
 ):
     """Step to enable clickhouse local query"""
     if node is None:
@@ -12,5 +17,7 @@ def clickhouse_local(
 
     with When("I make clickhouse local query"):
         node.command(
-            f'TZ={timezone} clickhouse local -q  "{query}" --multiquery', message=f"{message}"
+            f'TZ={timezone} clickhouse local -q  "{query}" --multiquery',
+            message=f"{message}",
+            exitcode=exitcode,
         )

--- a/ssl_keeper/helpers/cluster.py
+++ b/ssl_keeper/helpers/cluster.py
@@ -1260,7 +1260,7 @@ class Cluster(object):
                         cmd = self.command(
                             None,
                             f"{self.docker_compose} pull 2>&1 | tee",
-                            exitcode=None,
+                            no_checks=True,
                             timeout=timeout,
                         )
                         if cmd.exitcode != 0:
@@ -1273,7 +1273,7 @@ class Cluster(object):
                         cmd = self.command(
                             None,
                             f"{self.docker_compose} down 2>&1 | tee",
-                            exitcode=None,
+                            no_checks=True,
                             timeout=timeout,
                         )
                         if cmd.exitcode != 0:

--- a/ssl_server/tests/ca_chain/steps.py
+++ b/ssl_server/tests/ca_chain/steps.py
@@ -89,10 +89,10 @@ def create_node_server_certificate_with_chain_and_dh_params(
     if trusted_cas is not None:
         with And("I add trusted CA certificates to the node"):
             for trusted_ca in trusted_cas:
-                name = "_".join(trusted_ca.split(os.path.sep)[-2:])
-                with By(f"adding {name}"):
+                ca_name = "_".join(trusted_ca.split(os.path.sep)[-2:])
+                with By(f"adding {ca_name}"):
                     add_trusted_ca_certificate(
-                        node=node, certificate=trusted_ca, name=name
+                        node=node, certificate=trusted_ca, name=ca_name
                     )
 
     with And("I set correct permission on server key file"):

--- a/ssl_server/tests/ca_chain/steps.py
+++ b/ssl_server/tests/ca_chain/steps.py
@@ -183,10 +183,10 @@ def create_node_server_certificate_and_dh_params(
     if trusted_cas is not None:
         with And("I add trusted CA certificates to the node"):
             for trusted_ca in trusted_cas:
-                name = "_".join(trusted_ca.split(os.path.sep)[-2:])
-                with By(f"adding {name}"):
+                ca_name = "_".join(trusted_ca.split(os.path.sep)[-2:])
+                with By(f"adding {ca_name}"):
                     add_trusted_ca_certificate(
-                        node=node, certificate=trusted_ca, name=name
+                        node=node, certificate=trusted_ca, name=ca_name
                     )
 
     with And("I set correct permission on server key file"):

--- a/tiered_storage/tests/common.py
+++ b/tiered_storage/tests/common.py
@@ -22,11 +22,14 @@ def get_random_string(cluster, length, steps=True, *args, **kwargs):
             None,
             f"cat /dev/urandom | tr -dc 'A-Za-z0-9#$&()*+,-./:;<=>?@[\]^_~' | head -c {length} > {fd.name}",
             steps=steps,
+            no_checks=True,
             *args,
             **kwargs,
         )
         fd.seek(0)
-        return fd.read()
+        random_string = fd.read()
+        assert len(random_string) == length
+        return random_string
 
 
 def get_used_disks_for_table(node, name, step=When, steps=True):

--- a/tiered_storage/tests/no_warning_about_zero_max_data_part_size.py
+++ b/tiered_storage/tests/no_warning_about_zero_max_data_part_size.py
@@ -43,7 +43,7 @@ def scenario(self, cluster):
                 def check_log(cmd, exitcode=0):
                     cmd = node.command(
                         f"cat /var/log/clickhouse-server/clickhouse-server.log | {cmd}",
-                        exitcode=None,
+                        no_checks=True,
                     )
                     with Then(f"check exitcode is {exitcode}"):
                         assert cmd.exitcode == exitcode, error()

--- a/tiered_storage/tests/no_warning_about_zero_max_data_part_size.py
+++ b/tiered_storage/tests/no_warning_about_zero_max_data_part_size.py
@@ -42,7 +42,8 @@ def scenario(self, cluster):
 
                 def check_log(cmd, exitcode=0):
                     cmd = node.command(
-                        f"cat /var/log/clickhouse-server/clickhouse-server.log | {cmd}"
+                        f"cat /var/log/clickhouse-server/clickhouse-server.log | {cmd}",
+                        exitcode=None,
                     )
                     with Then(f"check exitcode is {exitcode}"):
                         assert cmd.exitcode == exitcode, error()


### PR DESCRIPTION
Change the default behaviour of Node.command/Cluster.command to check that exitcode=0 by default. Where this behaviour is not desired I have added the no_checks=True argument.

Outstanding issues:
 - ~~Keeper(-SSL): `Rm: cannot remove '/share/': Device or resource busy` https://github.com/Altinity/clickhouse-regression/actions/runs/6897741019/job/18766479611~~ 
   - Resolved by deleting contents of /share instead of the folder itself.
 - ~~SSL Server: tries to change permissions on a non-existent key. https://github.com/Altinity/clickhouse-regression/actions/runs/6897741019/job/18766484257~~
   - The variable `name` was used in loop, overriding the variable `name` which is used later. A perfect example of how this PR will help us.

Issues for review:
 - disk encryption/helpers/common: add_group_on_node() cleanup can fail with `The group 'clickhouse' does not exist.`
     - I have set no_checks=True on this, but I have not identified why the group disappears before being deleted
 - Kerberos: expected behaviour? https://github.com/Altinity/clickhouse-regression/actions/runs/6872354340/job/18690693455
     -   I have set no_checks=True on this, the `policy already exists` message indicates to me that this is intended to be ignored
 - Kerberos: This test appears to be written incorrectly /kerberos/generic/ping
 - Kafka: it's possible to enter an infinite retry loop if delete_any_old_topic_and_consumer_group() fails https://github.com/Altinity/clickhouse-regression/actions/runs/6872354340/job/18690693351
     - I'm unable to reproduce this locally
 - S3 and Tiered Storage, a command like this one `cat /dev/urandom | tr -dc 'A-Za-z0-9#$&()*+,-./:;<=>?@[\]^_~' | head -c 1048576 > /tmp/tmp60u4ho4p` exits with code 141 when run by the framework, but 0 when run manually in the container
   - I have set no_checks=True on this and added an output-based check for success
   
 Latest test run: https://github.com/Altinity/clickhouse-regression/actions/runs/7037627150