### PR TITLE
Autoclean docker instance volumes

### DIFF
--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -7,6 +7,7 @@ import threading
 import tempfile
 import re
 import json
+import shutil
 
 from testflows._core.cli.arg.common import description
 
@@ -997,6 +998,7 @@ class Cluster(object):
         use_zookeeper_nodes=False,
         frame=None,
         use_specific_version=False,
+        rm_instances_files=True,
     ):
         self._bash = {}
         self._control_shell = None
@@ -1052,6 +1054,9 @@ class Cluster(object):
             raise TypeError(
                 f"docker compose file '{docker_compose_file_path}' does not exist"
             )
+
+        if rm_instances_files:
+            shutil.rmtree(os.path.join(docker_compose_project_dir,"..","_instances"), ignore_errors=True)
 
         if self.clickhouse_binary_path:
             if self.use_specific_version:

--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -1470,9 +1470,16 @@ class Cluster(object):
             return cmd
 
     def open_instances_permissions(self, node):
-        """Add open permissions on all files and folders in _instances"""
+        """
+        Add open permissions on all files and folders in _instances.
+        
+        Will not do anything if cluster is already down.
+        """
         with self.lock:
-            container_id = self.node_container_id(node)
+            try:
+                container_id = self.node_container_id(node, timeout=1)
+            except RuntimeError:
+                return
 
         r = self.command(
             node=None, command=f"docker inspect {container_id}", exitcode=0

--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -1431,8 +1431,12 @@ class Cluster(object):
 
         # Edit permissions on server files for external manipulation
         for node in self.nodes["clickhouse"]:
-            self.command(node=node, command="chmod a+rwX -R /var/lib/clickhouse")
-            self.command(node=node, command="chmod a+rwX -R /var/log/clickhouse-server")
+            self.command(node=node, command="chmod a+rwX -R /var/lib/clickhouse", no_checks=True)
+            self.command(node=node, command="chmod a+rwX -R /var/log/clickhouse-server", no_checks=True)
+            self.command(node=node, command="chmod a+rwX -R /etc/clickhouse-server", no_checks=True)
+            self.command(node=node, command="chmod a+rwX -R /data", no_checks=True)
+            self.command(node=node, command="chmod a+rwX -R /datalog", no_checks=True)
+
 
         try:
             bash = self.bash(None)

--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -1441,7 +1441,10 @@ class Cluster(object):
         # Edit permissions on server files for external manipulation
         for node_type in ["clickhouse", "zookeeper", "keeper"]:
             for node in self.nodes.get(node_type, []):
-                self.open_instances_permissions(node=node)
+                try:
+                    self.open_instances_permissions(node=node)
+                except:
+                    pass
 
         try:
             bash = self.bash(None)

--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -1428,6 +1428,12 @@ class Cluster(object):
                     node=node,
                     command=f'echo -e "\n-- sending stop to: {node} --\n" >> /var/log/clickhouse-server/clickhouse-server.log',
                 )
+
+        # Edit permissions on server files for external manipulation
+        for node in self.nodes["clickhouse"]:
+            self.command(node=node, command="chmod a+rwX -R /var/lib/clickhouse")
+            self.command(node=node, command="chmod a+rwX -R /var/log/clickhouse-server")
+
         try:
             bash = self.bash(None)
             with self.lock:


### PR DESCRIPTION
Change file permissions inside `_instances` in `cluster.down`
Delete contents of `_instances` in `cluster.__init__` unless `rm_instances_files` is set to false

Latest test run https://github.com/Altinity/clickhouse-regression/actions/runs/7040647745