### PR TITLE
No python on clickhouse nodes

### DIFF
--- a/aes_encryption/aes_encryption_env/clickhouse-service.yml
+++ b/aes_encryption/aes_encryption_env/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/common.xml:/etc/clickhouse-server/common.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/aes_encryption/aes_encryption_env_arm64/clickhouse-service.yml
+++ b/aes_encryption/aes_encryption_env_arm64/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/common.xml:/etc/clickhouse-server/common.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/aggregate_functions/aggregate_functions_env/clickhouse-service.yml
+++ b/aggregate_functions/aggregate_functions_env/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/aggregate_functions/aggregate_functions_env_arm64/clickhouse-service.yml
+++ b/aggregate_functions/aggregate_functions_env_arm64/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/alter/alter_env/clickhouse-service.yml
+++ b/alter/alter_env/clickhouse-service.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: "2.3"
 
 services:
   clickhouse:
@@ -6,8 +6,6 @@ services:
       file: ../../docker-compose/clickhouse-service.yml
       service: clickhouse
     volumes:
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/corrupt_file:/usr/bin/corrupt_file"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/logs.xml:/etc/clickhouse-server/config.d/logs.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/ports.xml:/etc/clickhouse-server/config.d/ports.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/remote.xml:/etc/clickhouse-server/config.d/remote.xml"

--- a/alter/alter_env/clickhouse-service.yml
+++ b/alter/alter_env/clickhouse-service.yml
@@ -6,6 +6,7 @@ services:
       file: ../../docker-compose/clickhouse-service.yml
       service: clickhouse
     volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/../helpers/corrupt_file:/usr/bin/corrupt_file"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/logs.xml:/etc/clickhouse-server/config.d/logs.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/ports.xml:/etc/clickhouse-server/config.d/ports.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/remote.xml:/etc/clickhouse-server/config.d/remote.xml"

--- a/alter/alter_env/docker-compose.yml
+++ b/alter/alter_env/docker-compose.yml
@@ -124,6 +124,11 @@ services:
     volumes:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/postgres1/database:/var/lib/postgres"
 
+  bash-tools:
+    extends:
+      file: ../../docker-compose/bash-tools.yml
+      service: bash-tools
+
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy
   all_services_ready:

--- a/alter/alter_env/docker-compose.yml
+++ b/alter/alter_env/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.3'
 
 volumes:
   data1-1:
+  bash-tools:
 
 services:
   zookeeper1:
@@ -23,11 +24,13 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse1/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
 
     depends_on:
       zookeeper1:
         condition: service_healthy
+      bash-tools:
+        condition: service_started
 
   clickhouse-different-versions:
     extends:
@@ -38,7 +41,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse-different-versions/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse-different-versions/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse-different-versions/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -52,7 +55,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse2/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse2/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse2/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -66,7 +69,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse3/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse3/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse3/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -90,6 +93,7 @@ services:
     ports:
       - "8080"
     tty: true
+    init: true
     depends_on:
       - proxy1
       - proxy2
@@ -133,7 +137,7 @@ services:
       file: ../../docker-compose/bash-tools.yml
       service: bash-tools
     volumes:
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin
 
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy

--- a/alter/alter_env/docker-compose.yml
+++ b/alter/alter_env/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse1/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
 
     depends_on:
       zookeeper1:
@@ -37,6 +38,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse-different-versions/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse-different-versions/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse-different-versions/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -50,6 +52,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse2/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse2/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse2/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -63,6 +66,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse3/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse3/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse3/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -128,6 +132,8 @@ services:
     extends:
       file: ../../docker-compose/bash-tools.yml
       service: bash-tools
+    volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
 
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy

--- a/alter/alter_env_arm64/clickhouse-service.yml
+++ b/alter/alter_env_arm64/clickhouse-service.yml
@@ -11,6 +11,7 @@ services:
       - "9009"
       - "8123"
     volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/../helpers/corrupt_file:/usr/bin/corrupt_file"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/logs.xml:/etc/clickhouse-server/config.d/logs.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/ports.xml:/etc/clickhouse-server/config.d/ports.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/remote.xml:/etc/clickhouse-server/config.d/remote.xml"

--- a/alter/alter_env_arm64/clickhouse-service.yml
+++ b/alter/alter_env_arm64/clickhouse-service.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: "2.3"
 
 services:
   clickhouse:
@@ -11,8 +11,6 @@ services:
       - "9009"
       - "8123"
     volumes:
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/corrupt_file:/usr/bin/corrupt_file"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/logs.xml:/etc/clickhouse-server/config.d/logs.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/ports.xml:/etc/clickhouse-server/config.d/ports.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/remote.xml:/etc/clickhouse-server/config.d/remote.xml"

--- a/alter/alter_env_arm64/docker-compose.yml
+++ b/alter/alter_env_arm64/docker-compose.yml
@@ -124,6 +124,11 @@ services:
     volumes:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/postgres1/database:/var/lib/postgres"
 
+  bash-tools:
+    extends:
+      file: ../../docker-compose/bash-tools.yml
+      service: bash-tools
+
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy
   all_services_ready:

--- a/alter/alter_env_arm64/docker-compose.yml
+++ b/alter/alter_env_arm64/docker-compose.yml
@@ -25,9 +25,12 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse1/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
       - bash-tools:/usr/bin/bash-tools
+
     depends_on:
       zookeeper1:
         condition: service_healthy
+      bash-tools:
+        condition: service_started
 
   clickhouse-different-versions:
     extends:
@@ -134,7 +137,7 @@ services:
       file: ../../docker-compose/bash-tools.yml
       service: bash-tools
     volumes:
-      - bash-tools:/usr/bin/bash-tools
+      - bash-tools:/usr/bin
 
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy

--- a/alter/alter_env_arm64/docker-compose.yml
+++ b/alter/alter_env_arm64/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse1/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -37,6 +37,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse-different-versions/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse-different-versions/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse-different-versions/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -50,6 +51,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse2/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse2/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse2/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -63,6 +65,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse3/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse3/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse3/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -128,6 +131,8 @@ services:
     extends:
       file: ../../docker-compose/bash-tools.yml
       service: bash-tools
+    volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
 
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy

--- a/alter/alter_env_arm64/docker-compose.yml
+++ b/alter/alter_env_arm64/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.3'
 
 volumes:
   data1-1:
+  bash-tools:
 
 services:
   zookeeper1:
@@ -23,7 +24,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse1/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -37,7 +38,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse-different-versions/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse-different-versions/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse-different-versions/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -51,7 +52,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse2/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse2/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse2/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -65,7 +66,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse3/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse3/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse3/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -89,6 +90,7 @@ services:
     ports:
       - "8080"
     tty: true
+    init: true
     depends_on:
       - proxy1
       - proxy2
@@ -132,7 +134,7 @@ services:
       file: ../../docker-compose/bash-tools.yml
       service: bash-tools
     volumes:
-      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
+      - bash-tools:/usr/bin/bash-tools
 
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy

--- a/alter/table/attach_partition/corrupted_partitions.py
+++ b/alter/table/attach_partition/corrupted_partitions.py
@@ -60,7 +60,7 @@ def corrupt_parts_on_table_partition_detached(
             temp_path = f"/share/corrupt_files/{table_name}/detached/{part}/"
 
             node.command(
-                f"mkdir -p {originaltemp_path_path} && cp {original_path}data.bin {temp_path}"
+                f"mkdir -p {temp_path} && cp {original_path}data.bin {temp_path}"
             )
             bash_tools.command(f"corrupt_file {temp_path}data.bin {bits_to_corrupt}")
             node.command(f"cp {temp_path}data.bin {original_path}")

--- a/alter/table/attach_partition/corrupted_partitions.py
+++ b/alter/table/attach_partition/corrupted_partitions.py
@@ -25,20 +25,16 @@ after_attach_detached_part = {"1_1_1_0": "1_4_4_0", "1_2_2_0": "1_2_2_0"}
 def corrupt_parts_on_table_partition(self, table_name, parts, bits_to_corrupt=1500000):
     """Corrupt the selected part file."""
     node = self.context.node
-    bash_tools = self.context.cluster.node("bash-tools")
 
     with By(
         f"executing a corrupt_file script that will flip {bits_to_corrupt} bits on the {parts} part of the {table_name} table"
     ):
         for part in parts:
-            original_path = f"/var/lib/clickhouse/data/default/{table_name}/{part}/"
-            temp_path = f"/share/corrupt_files/{table_name}/{part}/"
-
             node.command(
-                f"mkdir -p {temp_path} && cp {original_path}data.bin {temp_path}"
+                "/usr/bin/bash-tools/python3 /usr/bin/corrupt_file "
+                f"/var/lib/clickhouse/data/default/{table_name}/{part}/data.bin {bits_to_corrupt}",
+                message="Corrupted",
             )
-            bash_tools.command(f"corrupt_file {temp_path}data.bin {bits_to_corrupt}")
-            node.command(f"cp {temp_path}data.bin {original_path}")
 
 
 @TestStep(When)
@@ -47,23 +43,17 @@ def corrupt_parts_on_table_partition_detached(
 ):
     """Corrupt the selected part file."""
     node = self.context.node
-    bash_tools = self.context.cluster.node("bash-tools")
 
     with By(
         f"executing a corrupt_file script that will flip {bits_to_corrupt} bits on the {parts} part of the {table_name} table"
     ):
-        node.command("mkdir -p /share/corrupt_files/" + table_name)
-        for part in parts:
-            original_path = (
-                f"/var/lib/clickhouse/data/default/{table_name}/detached/{part}/"
-            )
-            temp_path = f"/share/corrupt_files/{table_name}/detached/{part}/"
 
+        for part in parts:
             node.command(
-                f"mkdir -p {temp_path} && cp {original_path}data.bin {temp_path}"
+                "/usr/bin/bash-tools/python3 /usr/bin/corrupt_file "
+                f"/var/lib/clickhouse/data/default/{table_name}/detached/{part}/data.bin {bits_to_corrupt}",
+                message="Corrupted",
             )
-            bash_tools.command(f"corrupt_file {temp_path}data.bin {bits_to_corrupt}")
-            node.command(f"cp {temp_path}data.bin {original_path}")
 
 
 @TestCheck

--- a/alter/table/attach_partition/corrupted_partitions.py
+++ b/alter/table/attach_partition/corrupted_partitions.py
@@ -25,14 +25,20 @@ after_attach_detached_part = {"1_1_1_0": "1_4_4_0", "1_2_2_0": "1_2_2_0"}
 def corrupt_parts_on_table_partition(self, table_name, parts, bits_to_corrupt=1500000):
     """Corrupt the selected part file."""
     node = self.context.node
+    bash_tools = self.context.cluster.node("bash-tools")
 
     with By(
         f"executing a corrupt_file script that will flip {bits_to_corrupt} bits on the {parts} part of the {table_name} table"
     ):
         for part in parts:
+            original_path = f"/var/lib/clickhouse/data/default/{table_name}/{part}/"
+            temp_path = f"/share/corrupt_files/{table_name}/{part}/"
+
             node.command(
-                f"corrupt_file /var/lib/clickhouse/data/default/{table_name}/{part}/data.bin {bits_to_corrupt}"
+                f"mkdir -p {temp_path} && cp {original_path}data.bin {temp_path}"
             )
+            bash_tools.command(f"corrupt_file {temp_path}data.bin {bits_to_corrupt}")
+            node.command(f"cp {temp_path}data.bin {original_path}")
 
 
 @TestStep(When)
@@ -41,14 +47,23 @@ def corrupt_parts_on_table_partition_detached(
 ):
     """Corrupt the selected part file."""
     node = self.context.node
+    bash_tools = self.context.cluster.node("bash-tools")
 
     with By(
         f"executing a corrupt_file script that will flip {bits_to_corrupt} bits on the {parts} part of the {table_name} table"
     ):
+        node.command("mkdir -p /share/corrupt_files/" + table_name)
         for part in parts:
-            node.command(
-                f"corrupt_file /var/lib/clickhouse/data/default/{table_name}/detached/{part}/data.bin {bits_to_corrupt}"
+            original_path = (
+                f"/var/lib/clickhouse/data/default/{table_name}/detached/{part}/"
             )
+            temp_path = f"/share/corrupt_files/{table_name}/detached/{part}/"
+
+            node.command(
+                f"mkdir -p {originaltemp_path_path} && cp {original_path}data.bin {temp_path}"
+            )
+            bash_tools.command(f"corrupt_file {temp_path}data.bin {bits_to_corrupt}")
+            node.command(f"cp {temp_path}data.bin {original_path}")
 
 
 @TestCheck

--- a/alter/table/attach_partition/temporary_table.py
+++ b/alter/table/attach_partition/temporary_table.py
@@ -16,10 +16,11 @@ def check_attach_partition_detached_with_temporary_tables(self, table, engine):
     """Check if it is possible to use attach partition with temporary tables."""
 
     node = self.context.node
+    bash_tools = self.context.cluster.node("bash-tools")
     table_name = getuid()
 
     with Given("I open a single clickhouse instance"):
-        with node.client() as client:
+        with bash_tools.client(client_args={"host": node.name}) as client:
             with Given(
                 "I create a table",
                 description=f"""
@@ -114,6 +115,7 @@ def check_attach_partition_from_with_temporary_tables(
     """Check if it is possible to use attach partition from with temporary tables."""
 
     node = self.context.node
+    bash_tools = self.context.cluster.node("bash-tools")
     destination_table_name = "destination_" + getuid()
     source_table_name = "source_" + getuid()
 
@@ -132,7 +134,7 @@ def check_attach_partition_from_with_temporary_tables(
             )
 
     with Given("I open a single clickhouse instance"):
-        with node.client() as client:
+        with bash_tools.client(client_args={"host": node.name}) as client:
             with Given(
                 "I create two tables with specified engines and types",
                 description=f"""

--- a/alter/table/replace_partition/corrupted_partitions.py
+++ b/alter/table/replace_partition/corrupted_partitions.py
@@ -16,20 +16,16 @@ after_replace = {"1_1_1_0": "1_5_5_0", "1_2_2_0": "1_6_6_0", "1_3_3_0": "1_7_7_0
 def corrupt_parts_on_table_partition(self, table_name, parts, bits_to_corrupt=1500000):
     """Corrupt the selected part file."""
     node = self.context.node
-    bash_tools = self.context.cluster.node("bash-tools")
 
     with By(
         f"executing a corrupt_file script that will flip {bits_to_corrupt} bits on the {parts} part of the {table_name} table"
     ):
         for part in parts:
-            original_path = f"/var/lib/clickhouse/data/default/{table_name}/{part}/"
-            temp_path = f"/share/corrupt_files/{table_name}/{part}/"
-
             node.command(
-                f"mkdir -p {temp_path} && cp {original_path}data.bin {temp_path}"
+                "/usr/bin/bash-tools/python3 /usr/bin/corrupt_file "
+                f"/var/lib/clickhouse/data/default/{table_name}/{part}/data.bin {bits_to_corrupt}",
+                message="Corrupted",
             )
-            bash_tools.command(f"corrupt_file {temp_path}data.bin {bits_to_corrupt}")
-            node.command(f"cp {temp_path}data.bin {original_path}")
 
 
 @TestCheck

--- a/alter/table/replace_partition/temporary_table.py
+++ b/alter/table/replace_partition/temporary_table.py
@@ -14,6 +14,7 @@ from helpers.tables import create_table_partitioned_by_column
 def from_temporary_to_regular(self):
     """Check that it is possible to replace partition from the temporary table into a regular MergeTree table."""
     node = self.context.node
+    bash_tools = self.context.cluster.node("bash-tools")
     destination_table = "destination_" + getuid()
     source_table = "temporary_source_" + getuid()
 
@@ -24,7 +25,7 @@ def from_temporary_to_regular(self):
         create_partitions_with_random_uint64(table_name=destination_table)
 
     with And("I open a single clickhouse instance"):
-        with node.client() as client:
+        with bash_tools.client(client_args={"host": node.name}) as client:
             with When(
                 "I create a temporary table with the same structure as the destination table"
             ):
@@ -68,11 +69,12 @@ def from_temporary_to_regular(self):
 def from_temporary_to_temporary_table(self):
     """Check that it is not possible to replace partition from the temporary table into another temporary table."""
     node = self.context.node
+    bash_tools = self.context.cluster.node("bash-tools")
     destination_table = "temporary_destination_" + getuid()
     source_table = "temporary_source_" + getuid()
 
     with Given("I open a single clickhouse instance"):
-        with node.client() as client:
+        with bash_tools.client(client_args={"host": node.name}) as client:
             with And("I create two temporary tables with the same structure"):
                 client.query(
                     f"CREATE TEMPORARY TABLE {destination_table} (p UInt16,i UInt64,extra UInt8) ENGINE = MergeTree PARTITION BY p ORDER BY tuple();"
@@ -113,11 +115,12 @@ def from_temporary_to_temporary_table(self):
 def from_regular_to_temporary(self):
     """Check that it is not possible to replace partition from the regular table into temporary table."""
     node = self.context.node
+    bash_tools = self.context.cluster.node("bash-tools")
     destination_table = "temporary_destination_" + getuid()
     source_table = "source_" + getuid()
 
     with Given("I open a single clickhouse instance"):
-        with node.client() as client:
+        with bash_tools.client(client_args={"host": node.name}) as client:
             with And(
                 "I create one temporary table and one regular table with the same structure"
             ):

--- a/atomic_insert/atomic_insert_env/clickhouse-service.yml
+++ b/atomic_insert/atomic_insert_env/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/server.key:/etc/clickhouse-server/config.d/server.key"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/atomic_insert/atomic_insert_env_arm64/clickhouse-service.yml
+++ b/atomic_insert/atomic_insert_env_arm64/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/server.key:/etc/clickhouse-server/config.d/server.key"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/attach/attach_env/clickhouse-service.yml
+++ b/attach/attach_env/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/attach/attach_env_arm64/clickhouse-service.yml
+++ b/attach/attach_env_arm64/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/base_58/base_58_env/clickhouse-service.yml
+++ b/base_58/base_58_env/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/storage.xml:/etc/clickhouse-server/config.d/storage.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/base_58/base_58_env_arm64/clickhouse-service.yml
+++ b/base_58/base_58_env_arm64/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/storage.xml:/etc/clickhouse-server/config.d/storage.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/clickhouse_keeper/clickhouse_keeper_env/clickhouse-service.yml
+++ b/clickhouse_keeper/clickhouse_keeper_env/clickhouse-service.yml
@@ -23,7 +23,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/test_files/break-hash:/var/lib/break-hash"
       - "${CLICKHOUSE_TESTS_DIR}/test_files/https_app_file.py:/https_app_file.py"
       - "${CLICKHOUSE_TESTS_DIR}/test_files/http_app_file.py:/http_app_file.py"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
 
     deploy:
       resources:

--- a/clickhouse_keeper/clickhouse_keeper_env_arm64/clickhouse-service.yml
+++ b/clickhouse_keeper/clickhouse_keeper_env_arm64/clickhouse-service.yml
@@ -23,7 +23,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/test_files/break-hash:/var/lib/break-hash"
       - "${CLICKHOUSE_TESTS_DIR}/test_files/https_app_file.py:/https_app_file.py"
       - "${CLICKHOUSE_TESTS_DIR}/test_files/http_app_file.py:/http_app_file.py"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
 
     deploy:
       resources:

--- a/clickhouse_keeper/clickhouse_keeper_performance_env/clickhouse-service.yml
+++ b/clickhouse_keeper/clickhouse_keeper_performance_env/clickhouse-service.yml
@@ -27,7 +27,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/test_files/break-hash:/var/lib/break-hash"
       - "${CLICKHOUSE_TESTS_DIR}/test_files/https_app_file.py:/https_app_file.py"
       - "${CLICKHOUSE_TESTS_DIR}/test_files/http_app_file.py:/http_app_file.py"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
 
     entrypoint: bash -c "tail -f /dev/null"
     healthcheck:

--- a/data_types/data_types_env/clickhouse-service.yml
+++ b/data_types/data_types_env/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/data_types/data_types_env_arm64/clickhouse-service.yml
+++ b/data_types/data_types_env_arm64/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/remote.xml:/etc/clickhouse-server/config.d/remote.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/datetime64_extended_range/datetime64_extended_range_env/clickhouse-service.yml
+++ b/datetime64_extended_range/datetime64_extended_range_env/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/common.xml:/etc/clickhouse-server/common.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/datetime64_extended_range/datetime64_extended_range_env_arm64/clickhouse-service.yml
+++ b/datetime64_extended_range/datetime64_extended_range_env_arm64/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/disk_level_encryption/disk_level_encryption_env/clickhouse-service.yml
+++ b/disk_level_encryption/disk_level_encryption_env/clickhouse-service.yml
@@ -13,4 +13,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/disk_level_encryption/disk_level_encryption_env_arm64/clickhouse-service.yml
+++ b/disk_level_encryption/disk_level_encryption_env_arm64/clickhouse-service.yml
@@ -13,4 +13,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/dns/dns_env/clickhouse-service.yml
+++ b/dns/dns_env/clickhouse-service.yml
@@ -15,7 +15,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_SERVER_BIN_PATH:-/usr/bin/clickhouse}:/usr/bin/clickhouse"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
     entrypoint: bash -c "tail -f /dev/null"
     healthcheck:
       test: echo 1

--- a/dns/dns_env_arm64/clickhouse-service.yml
+++ b/dns/dns_env_arm64/clickhouse-service.yml
@@ -15,8 +15,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_SERVER_BIN_PATH:-/usr/bin/clickhouse}:/usr/bin/clickhouse"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
-
     entrypoint: bash -c "tail -f /dev/null"
     healthcheck:
       test: echo 1

--- a/docker-compose/bash-tools.yml
+++ b/docker-compose/bash-tools.yml
@@ -1,0 +1,14 @@
+version: "2.3"
+
+services:
+  bash-tools:
+    image: altinityinfra/clickhouse-regression-multiarch:2.0
+    hostname: bash-tools
+    init: true
+    restart: "no"
+    entrypoint:
+      - /bin/sleep
+    command:
+      - infinity
+    volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/docker-compose/bash-tools.yml
+++ b/docker-compose/bash-tools.yml
@@ -12,3 +12,4 @@ services:
       - infinity
     volumes:
       - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
+      - "${CLICKHOUSE_TESTS_DIR}/../helpers/corrupt_file:/usr/bin/corrupt_file"

--- a/docker-compose/bash-tools.yml
+++ b/docker-compose/bash-tools.yml
@@ -12,4 +12,3 @@ services:
       - infinity
     volumes:
       - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/corrupt_file:/usr/bin/corrupt_file"

--- a/engines/engines_env/clickhouse-service.yml
+++ b/engines/engines_env/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/engines/engines_env_arm64/clickhouse-service.yml
+++ b/engines/engines_env_arm64/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/example/example_env/clickhouse-service.yml
+++ b/example/example_env/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/example/example_env_arm64/clickhouse-service.yml
+++ b/example/example_env_arm64/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/extended_precision_data_types/extended_precision_data_types_env/clickhouse-service.yml
+++ b/extended_precision_data_types/extended_precision_data_types_env/clickhouse-service.yml
@@ -10,4 +10,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/storage.xml:/etc/clickhouse-server/config.d/storage.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/extended_precision_data_types/extended_precision_data_types_env_arm64/clickhouse-service.yml
+++ b/extended_precision_data_types/extended_precision_data_types_env_arm64/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/storage.xml:/etc/clickhouse-server/config.d/storage.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/functions/functions_env/docker-compose.yml
+++ b/functions/functions_env/docker-compose.yml
@@ -63,6 +63,11 @@ services:
       zookeeper1:
         condition: service_healthy
 
+  bash-tools:
+    extends:
+      file: ../../docker-compose/bash-tools.yml
+      service: bash-tools
+
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependecies will go healthy
   all_services_ready:

--- a/functions/functions_env_arm64/docker-compose.yml
+++ b/functions/functions_env_arm64/docker-compose.yml
@@ -63,6 +63,11 @@ services:
       zookeeper1:
         condition: service_healthy
 
+  bash-tools:
+    extends:
+      file: ../../docker-compose/bash-tools.yml
+      service: bash-tools
+
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependecies will go healthy
   all_services_ready:

--- a/functions/tests/plus.py
+++ b/functions/tests/plus.py
@@ -35,8 +35,9 @@ def floats(self, client=None):
 @Name("plus")
 def feature(self, node="clickhouse1"):
     self.context.node = self.context.cluster.node(node)
+    bash_tools = self.context.cluster.node("bash-tools")
 
-    with self.context.node.client() as client:
+    with bash_tools.client(client_args={"host": node}) as client:
         self.context.client = client
         for scenario in loads(current_module(), Scenario):
             scenario()

--- a/kafka/kafka_env/clickhouse-service.yml
+++ b/kafka/kafka_env/clickhouse-service.yml
@@ -18,4 +18,3 @@ services:
       - ${CLICKHOUSE_TESTS_DIR}/configs/dhparam.pem:/etc/clickhouse-server/dhparam.pem
       - ${CLICKHOUSE_TESTS_DIR}/configs/clickhouse-base/config.xml:/etc/clickhouse-server/config.xml
       - ${CLICKHOUSE_TESTS_DIR}/configs/clickhouse-base/users.xml:/etc/clickhouse-server/users.xml
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/kafka/kafka_env_arm64/clickhouse-service.yml
+++ b/kafka/kafka_env_arm64/clickhouse-service.yml
@@ -18,4 +18,3 @@ services:
       - ${CLICKHOUSE_TESTS_DIR}/configs/dhparam.pem:/etc/clickhouse-server/dhparam.pem
       - ${CLICKHOUSE_TESTS_DIR}/configs/clickhouse-base/config.xml:/etc/clickhouse-server/config.xml
       - ${CLICKHOUSE_TESTS_DIR}/configs/clickhouse-base/users.xml:/etc/clickhouse-server/users.xml
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/kerberos/kerberos_env/clickhouse-service.yml
+++ b/kerberos/kerberos_env/clickhouse-service.yml
@@ -10,7 +10,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/kerberos/etc/krb5.conf:/etc/krb5.conf"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
     environment:
       KRB5_CLIENT_KTNAME: /etc/krb5.keytab
       KRB5_KTNAME: /etc/krb5.keytab

--- a/kerberos/kerberos_env_arm64/clickhouse-service.yml
+++ b/kerberos/kerberos_env_arm64/clickhouse-service.yml
@@ -10,7 +10,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/kerberos/etc/krb5_arm64.conf:/etc/krb5.conf"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
     environment:
       KRB5_CLIENT_KTNAME: /etc/krb5.keytab
       KRB5_KTNAME: /etc/krb5.keytab

--- a/key_value/key_value_env/clickhouse-service.yml
+++ b/key_value/key_value_env/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/storage.xml:/etc/clickhouse-server/config.d/storage.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/key_value/key_value_env_arm64/clickhouse-service.yml
+++ b/key_value/key_value_env_arm64/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/storage.xml:/etc/clickhouse-server/config.d/storage.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ldap/authentication/authentication_env/clickhouse-service.yml
+++ b/ldap/authentication/authentication_env/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ldap/authentication/authentication_env_arm64/clickhouse-service.yml
+++ b/ldap/authentication/authentication_env_arm64/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ldap/external_user_directory/external_user_directory_env/clickhouse-service.yml
+++ b/ldap/external_user_directory/external_user_directory_env/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ldap/external_user_directory/external_user_directory_env_arm64/clickhouse-service.yml
+++ b/ldap/external_user_directory/external_user_directory_env_arm64/clickhouse-service.yml
@@ -11,4 +11,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ldap/role_mapping/role_mapping_env/clickhouse-service.yml
+++ b/ldap/role_mapping/role_mapping_env/clickhouse-service.yml
@@ -19,4 +19,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl/server.key:/etc/clickhouse-server/ssl/server.key"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ldap/role_mapping/role_mapping_env_arm64/clickhouse-service.yml
+++ b/ldap/role_mapping/role_mapping_env_arm64/clickhouse-service.yml
@@ -19,4 +19,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl/server.key:/etc/clickhouse-server/ssl/server.key"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/lightweight_delete/lightweight_delete_env/clickhouse-service.yml
+++ b/lightweight_delete/lightweight_delete_env/clickhouse-service.yml
@@ -13,4 +13,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/lightweight_delete/lightweight_delete_env_arm64/clickhouse-service.yml
+++ b/lightweight_delete/lightweight_delete_env_arm64/clickhouse-service.yml
@@ -13,4 +13,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/memory/memory_env/clickhouse-service.yml
+++ b/memory/memory_env/clickhouse-service.yml
@@ -14,4 +14,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/server.key:/etc/clickhouse-server/config.d/server.key"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/memory/memory_env_arm64/clickhouse-service.yml
+++ b/memory/memory_env_arm64/clickhouse-service.yml
@@ -14,4 +14,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/server.key:/etc/clickhouse-server/config.d/server.key"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ontime_benchmark/ontime_benchmark_env/clickhouse-service.yml
+++ b/ontime_benchmark/ontime_benchmark_env/clickhouse-service.yml
@@ -20,4 +20,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ontime_benchmark/ontime_benchmark_env_arm64/clickhouse-service.yml
+++ b/ontime_benchmark/ontime_benchmark_env_arm64/clickhouse-service.yml
@@ -20,4 +20,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/parquet/data/local_app.py
+++ b/parquet/data/local_app.py
@@ -7,14 +7,14 @@ app.secret_key = b'_5#y2L"F4Q8z\n\xec]/'
 @app.route("/<path:file_name>", methods=["GET"])
 def read_file(file_name):
     """Read binary data from specified file."""
-    path = f"/var/lib/app_files/{file_name}"
+    path = f"/share/app_files/{file_name}"
     return send_file(path)
 
 
 @app.route("/<path:file_name>", methods=["POST"])
 def write_file(file_name):
     """Append binary data to specified file."""
-    with open(f"/var/lib/app_files/{file_name}", "ab") as file:
+    with open(f"/share/app_files/{file_name}", "ab") as file:
         file.write(request.data)
     return ""
 
@@ -26,4 +26,4 @@ def life_check():
 
 
 if __name__ == "__main__":
-    app.run(port=5000, debug=True)
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/parquet/parquet_env/bash-tools.yml
+++ b/parquet/parquet_env/bash-tools.yml
@@ -1,0 +1,43 @@
+version: "2.3"
+
+services:
+  bash-tools:
+    extends:
+      file: ../../docker-compose/bash-tools.yml
+      service: bash-tools
+    volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/data/clickhouse_table_def.txt:/var/lib/test_files/clickhouse_table_def.txt"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_NONE.Parquet:/var/lib/test_files/data_NONE.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_BROTLI.Parquet:/var/lib/test_files/data_BROTLI.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_GZIP.Parquet:/var/lib/test_files/data_GZIP.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_SNAPPY.Parquet:/var/lib/test_files/data_SNAPPY.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_ZSTD.Parquet:/var/lib/test_files/data_ZSTD.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_LZ4.Parquet:/var/lib/test_files/data_LZ4.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/generate_chunked_file.py:/var/lib/test_files/generate_chunked_file.py"
+      - "${CLICKHOUSE_TESTS_DIR}/data/int-list-zero-based-chunked-array.parquet:/var/lib/test_files/int-list-zero-based-chunked-array.parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/list_monotonically_increasing_offsets.parquet:/var/lib/test_files/list_monotonically_increasing_offsets.parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/local_app.py:/var/lib/test_files/local_app.py"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_NONE.Parquet:/var/lib/clickhouse/user_files/data_NONE.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_BROTLI.Parquet:/var/lib/clickhouse/user_files/data_BROTLI.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_GZIP.Parquet:/var/lib/clickhouse/user_files/data_GZIP.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_SNAPPY.Parquet:/var/lib/clickhouse/user_files/data_SNAPPY.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_ZSTD.Parquet:/var/lib/clickhouse/user_files/data_ZSTD.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_LZ4.Parquet:/var/lib/clickhouse/user_files/data_LZ4.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/broken:/var/lib/clickhouse/user_files/broken"
+      - "${CLICKHOUSE_TESTS_DIR}/data/arrow:/var/lib/clickhouse/user_files/arrow"
+      - "${CLICKHOUSE_TESTS_DIR}/data/encrypted:/var/lib/clickhouse/user_files/encrypted"
+      - "${CLICKHOUSE_TESTS_DIR}/data/bloom:/var/lib/clickhouse/user_files/bloom"
+      - "${CLICKHOUSE_TESTS_DIR}/data/decimal:/var/lib/clickhouse/user_files/decimal"
+      - "${CLICKHOUSE_TESTS_DIR}/data/compression:/var/lib/clickhouse/user_files/compression"
+      - "${CLICKHOUSE_TESTS_DIR}/data/cache:/var/lib/clickhouse/user_files/cache"
+      - "${CLICKHOUSE_TESTS_DIR}/data/glob:/var/lib/clickhouse/user_files/glob"
+      - "${CLICKHOUSE_TESTS_DIR}/data/glob2:/var/lib/clickhouse/user_files/glob2"
+      - "${CLICKHOUSE_TESTS_DIR}/data/glob3:/var/lib/clickhouse/user_files/glob3"
+      - "${CLICKHOUSE_TESTS_DIR}/data/glob_million:/var/lib/clickhouse/user_files/glob_million"
+      - "${CLICKHOUSE_TESTS_DIR}/data/datatypes:/var/lib/clickhouse/user_files/datatypes"
+      - "${CLICKHOUSE_TESTS_DIR}/data/fastparquet:/var/lib/clickhouse/user_files/fastparquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/encodings:/var/lib/clickhouse/user_files/encodings"
+      - "${CLICKHOUSE_TESTS_DIR}/data/hive-partitioning:/var/lib/clickhouse/user_files/hive-partitioning"
+      - "${CLICKHOUSE_TESTS_DIR}/data/h2oai:/var/lib/clickhouse/user_files/h2oai"
+      - "${CLICKHOUSE_TESTS_DIR}/data/malloy-smaller:/var/lib/clickhouse/user_files/malloy-smaller"
+      - "${CLICKHOUSE_TESTS_DIR}/data/filters:/var/lib/clickhouse/user_files/filters"

--- a/parquet/parquet_env/clickhouse-service.yml
+++ b/parquet/parquet_env/clickhouse-service.yml
@@ -49,4 +49,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/parquet/parquet_env/docker-compose.yml
+++ b/parquet/parquet_env/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse1/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -72,6 +73,7 @@ services:
     ports:
       - "8080"
     tty: true
+    init: true
     depends_on:
       - proxy1
       - proxy2
@@ -109,6 +111,14 @@ services:
     hostname: postgres1
     volumes:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/postgres1/database:/var/lib/postgres"
+
+  bash-tools:
+    extends:
+      file: bash-tools.yml
+      service: bash-tools
+    hostname: bash-tools
+    volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
 
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy

--- a/parquet/parquet_env_arm64/bash-tools.yml
+++ b/parquet/parquet_env_arm64/bash-tools.yml
@@ -1,0 +1,43 @@
+version: "2.3"
+
+services:
+  bash-tools:
+    extends:
+      file: ../../docker-compose/bash-tools.yml
+      service: bash-tools
+    volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/data/clickhouse_table_def.txt:/var/lib/test_files/clickhouse_table_def.txt"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_NONE.Parquet:/var/lib/test_files/data_NONE.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_BROTLI.Parquet:/var/lib/test_files/data_BROTLI.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_GZIP.Parquet:/var/lib/test_files/data_GZIP.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_SNAPPY.Parquet:/var/lib/test_files/data_SNAPPY.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_ZSTD.Parquet:/var/lib/test_files/data_ZSTD.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_LZ4.Parquet:/var/lib/test_files/data_LZ4.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/generate_chunked_file.py:/var/lib/test_files/generate_chunked_file.py"
+      - "${CLICKHOUSE_TESTS_DIR}/data/int-list-zero-based-chunked-array.parquet:/var/lib/test_files/int-list-zero-based-chunked-array.parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/list_monotonically_increasing_offsets.parquet:/var/lib/test_files/list_monotonically_increasing_offsets.parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/local_app.py:/var/lib/test_files/local_app.py"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_NONE.Parquet:/var/lib/clickhouse/user_files/data_NONE.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_BROTLI.Parquet:/var/lib/clickhouse/user_files/data_BROTLI.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_GZIP.Parquet:/var/lib/clickhouse/user_files/data_GZIP.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_SNAPPY.Parquet:/var/lib/clickhouse/user_files/data_SNAPPY.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_ZSTD.Parquet:/var/lib/clickhouse/user_files/data_ZSTD.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/data_LZ4.Parquet:/var/lib/clickhouse/user_files/data_LZ4.Parquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/broken:/var/lib/clickhouse/user_files/broken"
+      - "${CLICKHOUSE_TESTS_DIR}/data/arrow:/var/lib/clickhouse/user_files/arrow"
+      - "${CLICKHOUSE_TESTS_DIR}/data/encrypted:/var/lib/clickhouse/user_files/encrypted"
+      - "${CLICKHOUSE_TESTS_DIR}/data/bloom:/var/lib/clickhouse/user_files/bloom"
+      - "${CLICKHOUSE_TESTS_DIR}/data/decimal:/var/lib/clickhouse/user_files/decimal"
+      - "${CLICKHOUSE_TESTS_DIR}/data/compression:/var/lib/clickhouse/user_files/compression"
+      - "${CLICKHOUSE_TESTS_DIR}/data/cache:/var/lib/clickhouse/user_files/cache"
+      - "${CLICKHOUSE_TESTS_DIR}/data/glob:/var/lib/clickhouse/user_files/glob"
+      - "${CLICKHOUSE_TESTS_DIR}/data/glob2:/var/lib/clickhouse/user_files/glob2"
+      - "${CLICKHOUSE_TESTS_DIR}/data/glob3:/var/lib/clickhouse/user_files/glob3"
+      - "${CLICKHOUSE_TESTS_DIR}/data/glob_million:/var/lib/clickhouse/user_files/glob_million"
+      - "${CLICKHOUSE_TESTS_DIR}/data/datatypes:/var/lib/clickhouse/user_files/datatypes"
+      - "${CLICKHOUSE_TESTS_DIR}/data/fastparquet:/var/lib/clickhouse/user_files/fastparquet"
+      - "${CLICKHOUSE_TESTS_DIR}/data/encodings:/var/lib/clickhouse/user_files/encodings"
+      - "${CLICKHOUSE_TESTS_DIR}/data/hive-partitioning:/var/lib/clickhouse/user_files/hive-partitioning"
+      - "${CLICKHOUSE_TESTS_DIR}/data/h2oai:/var/lib/clickhouse/user_files/h2oai"
+      - "${CLICKHOUSE_TESTS_DIR}/data/malloy-smaller:/var/lib/clickhouse/user_files/malloy-smaller"
+      - "${CLICKHOUSE_TESTS_DIR}/data/filters:/var/lib/clickhouse/user_files/filters"

--- a/parquet/parquet_env_arm64/clickhouse-service.yml
+++ b/parquet/parquet_env_arm64/clickhouse-service.yml
@@ -49,4 +49,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/parquet/parquet_env_arm64/docker-compose.yml
+++ b/parquet/parquet_env_arm64/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/database/:/var/lib/clickhouse/"
       - "${CLICKHOUSE_TESTS_DIR}/_instances/clickhouse1/logs/:/var/log/clickhouse-server/"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse1/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
     depends_on:
       zookeeper1:
         condition: service_healthy
@@ -116,6 +117,8 @@ services:
       file: bash-tools.yml
       service: bash-tools
     hostname: bash-tools
+    volumes:
+      - "${CLICKHOUSE_TESTS_DIR}/_instances/share:/share"
 
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy

--- a/parquet/parquet_env_arm64/docker-compose.yml
+++ b/parquet/parquet_env_arm64/docker-compose.yml
@@ -72,6 +72,7 @@ services:
     ports:
       - "8080"
     tty: true
+    init: true
     depends_on:
       - proxy1
       - proxy2
@@ -109,6 +110,12 @@ services:
     hostname: postgres1
     volumes:
       - "${CLICKHOUSE_TESTS_DIR}/_instances/postgres1/database:/var/lib/postgres"
+
+  bash-tools:
+    extends:
+      file: bash-tools.yml
+      service: bash-tools
+    hostname: bash-tools
 
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependencies will go healthy

--- a/parquet/tests/url.py
+++ b/parquet/tests/url.py
@@ -15,7 +15,7 @@ def insert_into_engine(self):
     with Given("I have a table with a `URL` engine"):
         table = create_table(
             name=table_name,
-            engine=f"URL('http://127.0.0.1:5000/{table_name}.Parquet', 'Parquet')",
+            engine=f"URL('http://bash-tools:5000/{table_name}.Parquet', 'Parquet')",
             columns=generate_all_column_types(include=parquet_test_columns()),
         )
 
@@ -29,7 +29,7 @@ def insert_into_engine(self):
         "I check that the data inserted into the table was correctly written to the file"
     ):
         node.command(
-            f"cp /var/lib/app_files/{table_name}.Parquet /var/lib/clickhouse/user_files/{table_name}.Parquet"
+            f"cp /share/app_files/{table_name}.Parquet /var/lib/clickhouse/user_files/{table_name}.Parquet"
         )
         check_source_file(
             path=f"/var/lib/clickhouse/user_files/{table_name}.Parquet",
@@ -54,7 +54,7 @@ def select_from_engine(self):
     with Given("I attach a table with a `URL` engine on top of a Parquet file"):
         create_table(
             name=table_name,
-            engine="URL('http://127.0.0.1:5000/data_NONE.Parquet', 'Parquet')",
+            engine="URL('http://bash-tools:5000/data_NONE.Parquet', 'Parquet')",
             columns=table_columns,
         )
 
@@ -86,7 +86,7 @@ def engine_to_file_to_engine(self):
     with Given("I have a table with a `URL` engine"):
         table0 = create_table(
             name=table0_name,
-            engine=f"URL('http://127.0.0.1:5000/{table0_name}.Parquet', 'Parquet')",
+            engine=f"URL('http://bash-tools:5000/{table0_name}.Parquet', 'Parquet')",
             columns=generate_all_column_types(include=parquet_test_columns()),
         )
 
@@ -100,7 +100,7 @@ def engine_to_file_to_engine(self):
         "I check that the data inserted into the table was correctly written into the file"
     ):
         node.command(
-            f"cp /var/lib/app_files/{table0_name}.Parquet /var/lib/clickhouse/user_files/{table0_name}.Parquet"
+            f"cp /share/app_files/{table0_name}.Parquet /var/lib/clickhouse/user_files/{table0_name}.Parquet"
         )
         check_source_file(
             path=f"/var/lib/clickhouse/user_files/{table0_name}.Parquet",
@@ -109,13 +109,13 @@ def engine_to_file_to_engine(self):
 
     with When("I copy of the Parquet source file to a new directory"):
         node.command(
-            f"cp /var/lib/app_files/{table0_name}.Parquet /var/lib/app_files/{table1_name}.Parquet"
+            f"cp /share/app_files/{table0_name}.Parquet /share/app_files/{table1_name}.Parquet"
         )
 
     with Given("I have a table with a `URL` engine"):
         table1 = create_table(
             name=table1_name,
-            engine=f"URL('http://127.0.0.1:5000/{table1_name}.Parquet', 'Parquet')",
+            engine=f"URL('http://bash-tools:5000/{table1_name}.Parquet', 'Parquet')",
             columns=generate_all_column_types(include=parquet_test_columns()),
         )
 
@@ -175,7 +175,7 @@ def insert_into_engine_from_file(self, compression_type):
     with Given("I have a table with a `URL` engine"):
         create_table(
             name=table_name,
-            engine=f"URL('http://127.0.0.1:5000/{table_name}.Parquet', 'Parquet')",
+            engine=f"URL('http://bash-tools:5000/{table_name}.Parquet', 'Parquet')",
             columns=table_columns,
         )
 
@@ -225,7 +225,7 @@ def engine_select_output_to_file(self, compression_type):
     with Given("I have a table with a `URL` engine"):
         table = create_table(
             name=table_name,
-            engine=f"URL('http://127.0.0.1:5000/{table_name}.Parquet', 'Parquet')",
+            engine=f"URL('http://bash-tools:5000/{table_name}.Parquet', 'Parquet')",
             columns=generate_all_column_types(include=parquet_test_columns()),
         )
 
@@ -284,7 +284,7 @@ def insert_into_function(self):
         description="insert data includes all of the ClickHouse data types supported by Parquet, including nested types and nulls",
     ):
         node.query(
-            f"INSERT INTO FUNCTION url('http://127.0.0.1:5000/{file_name}', 'Parquet', '{func_def}') VALUES {','.join(total_values)}",
+            f"INSERT INTO FUNCTION url('http://bash-tools:5000/{file_name}', 'Parquet', '{func_def}') VALUES {','.join(total_values)}",
             settings=[("allow_suspicious_low_cardinality_types", 1)],
         )
 
@@ -292,7 +292,7 @@ def insert_into_function(self):
         "I insert the data from the 'file' table function into a MergeTree engine table"
     ):
         node.command(
-            f"cp /var/lib/app_files/{file_name} /var/lib/clickhouse/user_files/{file_name}"
+            f"cp /share/app_files/{file_name} /var/lib/clickhouse/user_files/{file_name}"
         )
         node.query(
             f"INSERT INTO {table_name} FROM INFILE '/var/lib/clickhouse/user_files/{file_name}' FORMAT Parquet",
@@ -321,7 +321,7 @@ def select_from_function_manual_cast_types(self):
         for column in table_columns:
             with Check(f"{column.name}"):
                 execute_query(
-                    f"SELECT {column.name}, toTypeName({column.name}) FROM url('http://127.0.0.1:5000/data_NONE.Parquet', 'Parquet', '{table_def}')"
+                    f"SELECT {column.name}, toTypeName({column.name}) FROM url('http://bash-tools:5000/data_NONE.Parquet', 'Parquet', '{table_def}')"
                 )
 
 
@@ -340,7 +340,7 @@ def select_from_function_auto_cast_types(self):
         for column in table_columns:
             with Check(f"{column.name}"):
                 execute_query(
-                    f"SELECT {column.name}, toTypeName({column.name}) FROM url('http://127.0.0.1:5000/data_NONE.Parquet', 'Parquet')"
+                    f"SELECT {column.name}, toTypeName({column.name}) FROM url('http://bash-tools:5000/data_NONE.Parquet', 'Parquet')"
                 )
 
 
@@ -405,12 +405,13 @@ def function(self):
 def feature(self, node="clickhouse1"):
     """Run checks for `URL()` table engine and `url` table function when used with Parquet format."""
     self.context.node = self.context.cluster.node(node)
+    bash_tools = self.context.cluster.node("bash-tools")
 
     with Given("I have a directory for the flask server"):
-        self.context.node.command("mkdir /var/lib/app_files")
-        self.context.node.command("cp /var/lib/test_files/* /var/lib/app_files")
+        bash_tools.command("mkdir /share/app_files")
+        bash_tools.command("cp /var/lib/test_files/* /share/app_files")
 
-    with self.context.cluster.shell(self.context.node.name) as bash:
+    with self.context.cluster.shell("bash-tools") as bash:
         cmd = "python3 /var/lib/test_files/local_app.py"
 
         try:

--- a/part_moves_between_shards/part_moves_between_shards_env/clickhouse-service.yml
+++ b/part_moves_between_shards/part_moves_between_shards_env/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/dhparam.pem:/etc/clickhouse-server/config.d/dhparam.pem"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/server.crt:/etc/clickhouse-server/config.d/server.crt"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/server.key:/etc/clickhouse-server/config.d/server.key"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/part_moves_between_shards/part_moves_between_shards_env_arm64/clickhouse-service.yml
+++ b/part_moves_between_shards/part_moves_between_shards_env_arm64/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/dhparam.pem:/etc/clickhouse-server/config.d/dhparam.pem"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/server.crt:/etc/clickhouse-server/config.d/server.crt"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/server.key:/etc/clickhouse-server/config.d/server.key"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/rbac/rbac_env/docker-compose.yml
+++ b/rbac/rbac_env/docker-compose.yml
@@ -58,6 +58,11 @@ services:
       zookeeper1:
         condition: service_healthy
 
+  bash-tools:
+    extends:
+      file: ../../docker-compose/bash-tools.yml
+      service: bash-tools
+
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependecies will go healthy
   all_services_ready:

--- a/rbac/rbac_env_arm64/docker-compose.yml
+++ b/rbac/rbac_env_arm64/docker-compose.yml
@@ -58,6 +58,11 @@ services:
       zookeeper1:
         condition: service_healthy
 
+  bash-tools:
+    extends:
+      file: ../../docker-compose/bash-tools.yml
+      service: bash-tools
+
   # dummy service which does nothing, but allows to postpone
   # 'docker-compose up -d' till all dependecies will go healthy
   all_services_ready:

--- a/rbac/tests/privileges/multiple_auth_methods/actions.py
+++ b/rbac/tests/privileges/multiple_auth_methods/actions.py
@@ -89,7 +89,9 @@ def node_client(self, node=None):
     if node is None:
         node = self.context.node
 
-    with node.client() as client:
+    bash_tools = self.context.cluster.node("bash-tools")
+
+    with bash_tools.client(client_args={"host", node.name}) as client:
         yield client
 
 

--- a/s3/s3_env/clickhouse-service.yml
+++ b/s3/s3_env/clickhouse-service.yml
@@ -21,4 +21,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/ssl.xml:/etc/clickhouse-server/config.d/ssl.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/system_unfreeze.xml:/etc/clickhouse-server/config.d/system_unfreeze.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/s3/s3_env_arm64/clickhouse-service.yml
+++ b/s3/s3_env_arm64/clickhouse-service.yml
@@ -21,5 +21,4 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/system_unfreeze.xml:/etc/clickhouse-server/config.d/system_unfreeze.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/ssl:/etc/clickhouse-server/ssl"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
 

--- a/selects/selects_env/clickhouse-service.yml
+++ b/selects/selects_env/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/selects/selects_env_arm64/clickhouse-service.yml
+++ b/selects/selects_env_arm64/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/session_timezone/session_timezone_env/clickhouse-service.yml
+++ b/session_timezone/session_timezone_env/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/common.xml:/etc/clickhouse-server/common.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/session_timezone/session_timezone_env_arm64/clickhouse-service.yml
+++ b/session_timezone/session_timezone_env_arm64/clickhouse-service.yml
@@ -15,4 +15,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/common.xml:/etc/clickhouse-server/common.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ssl_keeper/ssl_keeper_env/clickhouse-service.yml
+++ b/ssl_keeper/ssl_keeper_env/clickhouse-service.yml
@@ -24,4 +24,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/client_fips.xml:/etc/clickhouse-client/config.d/fips.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/config.xml:/etc/clickhouse-client/config.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/ssl_keeper/ssl_keeper_env_arm64/clickhouse-service.yml
+++ b/ssl_keeper/ssl_keeper_env_arm64/clickhouse-service.yml
@@ -24,5 +24,4 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/client_fips.xml:/etc/clickhouse-client/config.d/fips.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/config.xml:/etc/clickhouse-client/config.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
 

--- a/ssl_server/ssl_server_env/clickhouse-service.yml
+++ b/ssl_server/ssl_server_env/clickhouse-service.yml
@@ -24,7 +24,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/test_files/http_app_file.py:/http_app_file.py"
       - "${CLICKHOUSE_TESTS_SERVER_BIN_PATH:-/usr/bin/clickhouse}:/usr/bin/clickhouse"
       - "${CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH:-/usr/bin/clickhouse-odbc-bridge}:/usr/bin/clickhouse-odbc-bridge"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
     entrypoint: bash -c "tail -f /dev/null"
     healthcheck:
       test: echo 1

--- a/ssl_server/ssl_server_env_arm64/clickhouse-service.yml
+++ b/ssl_server/ssl_server_env_arm64/clickhouse-service.yml
@@ -24,7 +24,6 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/test_files/http_app_file.py:/http_app_file.py"
       - "${CLICKHOUSE_TESTS_SERVER_BIN_PATH:-/usr/bin/clickhouse}:/usr/bin/clickhouse"
       - "${CLICKHOUSE_TESTS_ODBC_BRIDGE_BIN_PATH:-/usr/bin/clickhouse-odbc-bridge}:/usr/bin/clickhouse-odbc-bridge"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"
     entrypoint: bash -c "tail -f /dev/null"
     healthcheck:
       test: echo 1

--- a/tiered_storage/tiered_storage_env/clickhouse-service.yml
+++ b/tiered_storage/tiered_storage_env/clickhouse-service.yml
@@ -24,4 +24,3 @@ services:
       - ${CLICKHOUSE_TESTS_DIR}/configs/dhparam.pem:/etc/clickhouse-server/dhparam.pem
       - ${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml
       - ${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/tiered_storage/tiered_storage_env_arm64/clickhouse-service.yml
+++ b/tiered_storage/tiered_storage_env_arm64/clickhouse-service.yml
@@ -24,4 +24,3 @@ services:
       - ${CLICKHOUSE_TESTS_DIR}/configs/dhparam.pem:/etc/clickhouse-server/dhparam.pem
       - ${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml
       - ${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/window_functions/window_functions_env/clickhouse-service.yml
+++ b/window_functions/window_functions_env/clickhouse-service.yml
@@ -12,4 +12,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"

--- a/window_functions/window_functions_env_arm64/clickhouse-service.yml
+++ b/window_functions/window_functions_env_arm64/clickhouse-service.yml
@@ -13,4 +13,3 @@ services:
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.d/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml"
       - "${CLICKHOUSE_TESTS_DIR}/configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml"
-      - "${CLICKHOUSE_TESTS_DIR}/../helpers/clickhouse-client-tty:/usr/bin/clickhouse-client-tty"


### PR DESCRIPTION
Can't rely on Python being present in Clickhouse nodes in #50 

 - [x] move all calls to client-tty to bash-tools
 - [x] move any other Python scripts
   - [x] parquet/url flask server
   - [x] aggregate functions corrupt_file