### PR TITLE
Add test to verify users unchanged after rename exception

### DIFF
--- a/rbac/helper/common.py
+++ b/rbac/helper/common.py
@@ -370,3 +370,10 @@ def generate_bcrypt_hash(password):
     salt = bcrypt.gensalt()
     hashed = bcrypt.hashpw(password_bytes, salt).decode("utf-8")
     return hashed
+
+def user_exists(node, user_name):
+    """Check if a user exists in system.users and return True if found, False otherwise."""
+    result = node.query(
+        f"SELECT name FROM system.users WHERE name='{user_name}'",
+    ).output.strip()
+    return result == user_name


### PR DESCRIPTION
### Add test for ALTER USER RENAME exception validation

Add a new test case that verifies users remain unchanged after an exception is thrown when attempting to rename a user to a name that already exists.  
This test detects the bug described in ClickHouse upstream: https://github.com/ClickHouse/ClickHouse/issues/90320, where the user is actually renamed even though the exception is raised.  
It is also tracked in clickhouse-regression: https://github.com/Altinity/clickhouse-regression/issues/64.

Changes:
- Add test *"I alter user to rename, target unavailable, verify users unchanged after exception"* in `alter_user.py`
- Add `user_exists()` helper function in `rbac/helper/common.py` to check if a user exists in `system.users`
- Use the helper function to validate that both `old_user` and `new_user` exist (and remain correct) before and after the exception
