### PR TITLE
xfail version format tests in PR builds

### DIFF
--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -652,31 +652,20 @@ class ClickHouseNode(Node):
                 "fsanitize=undefined": "ubsan",
             }
             build_option = next(
-                (name for flag, name in sanitizers.items() if flag in output), None
+               (name for flag, name in sanitizers.items() if flag in output), {}
             )
             current().context.build_options = getattr(
                 current().context, "build_options", {}
             )
             current().context.build_options[self.name] = build_option
 
-            query = (
-                "SELECT * FROM system.build_options "
-                "WHERE name = 'CXX_FLAGS' FORMAT TabSeparated"
-            )
-            output = self.query(query, no_checks=1, steps=False).output
-            sanitizers = {
-                "fsanitize=thread": "tsan",
-                "fsanitize=memory": "msan",
-                "fsanitize=address": "asan",
-                "fsanitize=undefined": "ubsan",
-            }
-            build_option = next(
-                (name for flag, name in sanitizers.items() if flag in output), None
-            )
-            current().context.build_options = getattr(
-                current().context, "build_options", {}
-            )
-            current().context.build_options[self.name] = build_option
+            git_branch = self.query(
+                "SELECT value FROM system.build_options WHERE name = 'GIT_BRANCH' FORMAT TabSeparated",
+                no_checks=1,
+                steps=False,
+            ).output.strip()
+
+            current().context.build_options[self.name]["git_branch"] = git_branch
 
     def clickhouse_pid(self):
         """

--- a/version/regression.py
+++ b/version/regression.py
@@ -46,6 +46,23 @@ xfails = {
             check_clickhouse_version("<25.3"),
         ),
     ],
+    "/version/altinity/error message/": [
+        (
+            Fail,
+            "Not expected to pass on PR builds",
+            lambda test: test.context.build_options["clickhouse1"]["git_branch"]
+            == "HEAD",
+            ".*Expected message '\(altinity build\)' not found in log.*",
+        ),
+    ],
+    "/version/altinity/version format/": [
+        (
+            Fail,
+            "Not expected to pass on PR builds",
+            lambda test: test.context.build_options["clickhouse1"]["git_branch"]
+            == "HEAD",
+        ),
+    ],
 }
 
 


### PR DESCRIPTION
I'm unsure if the changes to cluster.py will have side effects