### PR TITLE
Add tests for CLEAR COLUMN IN PARTITION in SummingMergeTree

### DIFF
--- a/engines/regression.py
+++ b/engines/regression.py
@@ -17,15 +17,15 @@ xfails = {
     "/engines/summing_merge_tree/zero row deletion with clear column": [
         (
             Fail,
-            "https://github.com/ClickHouse/ClickHouse/issues/101953"
-            " — CLEAR COLUMN sets default state not recognized as zero by SummingSortedAlgorithm since 25.8",
+            "https://github.com/ClickHouse/ClickHouse/issues/101953 - fixed in >=26.6",
+            check_clickhouse_version("<26.6"),
         )
     ],
     "/engines/summing_merge_tree/clear column validation consistency": [
         (
             Fail,
-            "https://github.com/ClickHouse/ClickHouse/issues/101953"
-            " — CLEAR COLUMN allowed on auto-detected summing columns but blocked on explicit ones",
+            "https://github.com/ClickHouse/ClickHouse/issues/101953 - fixed in >=26.6",
+            check_clickhouse_version("<26.6"),
         )
     ],
 }

--- a/engines/regression.py
+++ b/engines/regression.py
@@ -13,7 +13,22 @@ from helpers.common import check_clickhouse_version, experimental_analyzer
 from engines.requirements import *
 
 
-xfails = {}
+xfails = {
+    "/engines/summing_merge_tree/zero row deletion with clear column": [
+        (
+            Fail,
+            "https://github.com/ClickHouse/ClickHouse/issues/101953"
+            " — CLEAR COLUMN sets default state not recognized as zero by SummingSortedAlgorithm since 25.8",
+        )
+    ],
+    "/engines/summing_merge_tree/clear column validation consistency": [
+        (
+            Fail,
+            "https://github.com/ClickHouse/ClickHouse/issues/101953"
+            " — CLEAR COLUMN allowed on auto-detected summing columns but blocked on explicit ones",
+        )
+    ],
+}
 xflags = {}
 
 
@@ -58,6 +73,12 @@ def regression(
     Feature(
         run=load(
             "engines.tests.replacing_merge_tree.replicated_replacing_merge_tree",
+            "feature",
+        )
+    )
+    Feature(
+        run=load(
+            "engines.tests.summing_merge_tree.summing_merge_tree",
             "feature",
         )
     )

--- a/engines/requirements/__init__.py
+++ b/engines/requirements/__init__.py
@@ -1,1 +1,2 @@
 from .replacing_merge_tree import *
+from .summing_merge_tree import *

--- a/engines/requirements/summing_merge_tree.md
+++ b/engines/requirements/summing_merge_tree.md
@@ -1,0 +1,64 @@
+# SRS-046 ClickHouse SummingMergeTree
+# Software Requirements Specification
+
+## Table of Contents
+
+* 1 [Introduction](#introduction)
+* 2 [Related Resources](#related-resources)
+* 3 [Terminology](#terminology)
+* 4 [Requirements](#requirements)
+  * 4.1 [RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.Update](#rqsrs-046clickhousesummingmergetreezerorowdeletionupdate)
+  * 4.2 [RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.ClearColumn](#rqsrs-046clickhousesummingmergetreezerorowdeletionclearcolumn)
+  * 4.3 [RQ.SRS-046.ClickHouse.SummingMergeTree.ClearColumn.Consistency](#rqsrs-046clickhousesummingmergetreeclearcolumnconsistency)
+
+
+## Introduction
+
+This software requirements specification covers requirements related to the
+[ClickHouse] [SummingMergeTree] engine, specifically zero-row deletion after merges
+and the consistency of `ALTER TABLE ... CLEAR COLUMN` validation between explicit
+and auto-detected `columns_to_sum`.
+
+
+## Related Resources
+
+* https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/summingmergetree
+* https://github.com/ClickHouse/ClickHouse/issues/101953
+* https://github.com/ClickHouse/ClickHouse/pull/83892
+
+
+## Terminology
+
+#### SRS
+
+Software Requirements Specification
+
+
+## Requirements
+
+### RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.Update
+version: 1.0
+
+[SummingMergeTree] SHALL delete a row whose summing columns have been set to zero
+via `ALTER TABLE ... UPDATE` after `OPTIMIZE TABLE ... FINAL`.
+
+### RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.ClearColumn
+version: 1.0
+
+[SummingMergeTree] SHALL delete a row whose summing columns have been zeroed via
+`ALTER TABLE ... CLEAR COLUMN ... IN PARTITION ...` after `OPTIMIZE TABLE ... FINAL`,
+equivalently to the row being zeroed via `ALTER TABLE ... UPDATE`.
+
+### RQ.SRS-046.ClickHouse.SummingMergeTree.ClearColumn.Consistency
+version: 1.0
+
+[SummingMergeTree] SHALL apply the same `ALTER TABLE ... CLEAR COLUMN ... IN
+PARTITION ...` validation regardless of whether `columns_to_sum` was declared
+explicitly (`SummingMergeTree(c)`) or auto-detected (`SummingMergeTree`).
+
+
+## References
+
+[SRS]: #srs
+[ClickHouse]: https://clickhouse.com
+[SummingMergeTree]: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/summingmergetree/

--- a/engines/requirements/summing_merge_tree.py
+++ b/engines/requirements/summing_merge_tree.py
@@ -1,0 +1,163 @@
+# These requirements were auto generated
+# from software requirements specification (SRS)
+# document by TestFlows v2.0.250110.1002922.
+# Do not edit by hand but re-generate instead
+# using 'tfs requirements generate' command.
+from testflows.core import Specification
+from testflows.core import Requirement
+
+Heading = Specification.Heading
+
+RQ_SRS_046_ClickHouse_SummingMergeTree_ZeroRowDeletion_Update = Requirement(
+    name='RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.Update',
+    version='1.0',
+    priority=None,
+    group=None,
+    type=None,
+    uid=None,
+    description=(
+        '[SummingMergeTree] SHALL delete a row whose summing columns have been set to zero\n'
+        'via `ALTER TABLE ... UPDATE` after `OPTIMIZE TABLE ... FINAL`.\n'
+        '\n'
+    ),
+    link=None,
+    level=2,
+    num='4.1'
+)
+
+RQ_SRS_046_ClickHouse_SummingMergeTree_ZeroRowDeletion_ClearColumn = Requirement(
+    name='RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.ClearColumn',
+    version='1.0',
+    priority=None,
+    group=None,
+    type=None,
+    uid=None,
+    description=(
+        '[SummingMergeTree] SHALL delete a row whose summing columns have been zeroed via\n'
+        '`ALTER TABLE ... CLEAR COLUMN ... IN PARTITION ...` after `OPTIMIZE TABLE ... FINAL`,\n'
+        'equivalently to the row being zeroed via `ALTER TABLE ... UPDATE`.\n'
+        '\n'
+    ),
+    link=None,
+    level=2,
+    num='4.2'
+)
+
+RQ_SRS_046_ClickHouse_SummingMergeTree_ClearColumn_Consistency = Requirement(
+    name='RQ.SRS-046.ClickHouse.SummingMergeTree.ClearColumn.Consistency',
+    version='1.0',
+    priority=None,
+    group=None,
+    type=None,
+    uid=None,
+    description=(
+        '[SummingMergeTree] SHALL apply the same `ALTER TABLE ... CLEAR COLUMN ... IN\n'
+        'PARTITION ...` validation regardless of whether `columns_to_sum` was declared\n'
+        'explicitly (`SummingMergeTree(c)`) or auto-detected (`SummingMergeTree`).\n'
+        '\n'
+        '\n'
+    ),
+    link=None,
+    level=2,
+    num='4.3'
+)
+
+SRS_046_ClickHouse_SummingMergeTree = Specification(
+    name='SRS-046 ClickHouse SummingMergeTree',
+    description=None,
+    author=None,
+    date=None,
+    status=None,
+    approved_by=None,
+    approved_date=None,
+    approved_version=None,
+    version=None,
+    group=None,
+    type=None,
+    link=None,
+    uid=None,
+    parent=None,
+    children=None,
+    headings=(
+        Heading(name='Introduction', level=1, num='1'),
+        Heading(name='Related Resources', level=1, num='2'),
+        Heading(name='Terminology', level=1, num='3'),
+        Heading(name='SRS', level=3, num='3.0.1'),
+        Heading(name='Requirements', level=1, num='4'),
+        Heading(name='RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.Update', level=2, num='4.1'),
+        Heading(name='RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.ClearColumn', level=2, num='4.2'),
+        Heading(name='RQ.SRS-046.ClickHouse.SummingMergeTree.ClearColumn.Consistency', level=2, num='4.3'),
+        Heading(name='References', level=1, num='5'),
+        ),
+    requirements=(
+        RQ_SRS_046_ClickHouse_SummingMergeTree_ZeroRowDeletion_Update,
+        RQ_SRS_046_ClickHouse_SummingMergeTree_ZeroRowDeletion_ClearColumn,
+        RQ_SRS_046_ClickHouse_SummingMergeTree_ClearColumn_Consistency,
+        ),
+    content=r'''
+# SRS-046 ClickHouse SummingMergeTree
+# Software Requirements Specification
+
+## Table of Contents
+
+* 1 [Introduction](#introduction)
+* 2 [Related Resources](#related-resources)
+* 3 [Terminology](#terminology)
+* 4 [Requirements](#requirements)
+  * 4.1 [RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.Update](#rqsrs-046clickhousesummingmergetreezerorowdeletionupdate)
+  * 4.2 [RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.ClearColumn](#rqsrs-046clickhousesummingmergetreezerorowdeletionclearcolumn)
+  * 4.3 [RQ.SRS-046.ClickHouse.SummingMergeTree.ClearColumn.Consistency](#rqsrs-046clickhousesummingmergetreeclearcolumnconsistency)
+
+
+## Introduction
+
+This software requirements specification covers requirements related to the
+[ClickHouse] [SummingMergeTree] engine, specifically zero-row deletion after merges
+and the consistency of `ALTER TABLE ... CLEAR COLUMN` validation between explicit
+and auto-detected `columns_to_sum`.
+
+
+## Related Resources
+
+* https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/summingmergetree
+* https://github.com/ClickHouse/ClickHouse/issues/101953
+* https://github.com/ClickHouse/ClickHouse/pull/83892
+
+
+## Terminology
+
+#### SRS
+
+Software Requirements Specification
+
+
+## Requirements
+
+### RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.Update
+version: 1.0
+
+[SummingMergeTree] SHALL delete a row whose summing columns have been set to zero
+via `ALTER TABLE ... UPDATE` after `OPTIMIZE TABLE ... FINAL`.
+
+### RQ.SRS-046.ClickHouse.SummingMergeTree.ZeroRowDeletion.ClearColumn
+version: 1.0
+
+[SummingMergeTree] SHALL delete a row whose summing columns have been zeroed via
+`ALTER TABLE ... CLEAR COLUMN ... IN PARTITION ...` after `OPTIMIZE TABLE ... FINAL`,
+equivalently to the row being zeroed via `ALTER TABLE ... UPDATE`.
+
+### RQ.SRS-046.ClickHouse.SummingMergeTree.ClearColumn.Consistency
+version: 1.0
+
+[SummingMergeTree] SHALL apply the same `ALTER TABLE ... CLEAR COLUMN ... IN
+PARTITION ...` validation regardless of whether `columns_to_sum` was declared
+explicitly (`SummingMergeTree(c)`) or auto-detected (`SummingMergeTree`).
+
+
+## References
+
+[SRS]: #srs
+[ClickHouse]: https://clickhouse.com
+[SummingMergeTree]: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/summingmergetree/
+'''
+)

--- a/engines/tests/steps.py
+++ b/engines/tests/steps.py
@@ -5,6 +5,18 @@ from testflows.core import *
 from helpers.common import create_xml_config_content, add_config
 from helpers.common import getuid, instrument_clickhouse_server_log
 
+@TestStep(When)
+def insert_values_into_table(self, table_name, values, node=None):
+    """Insert one or more value tuples into a table."""
+    if node is None:
+        node = self.context.cluster.node("clickhouse1")
+
+    if not isinstance(values, str):
+        values = ", ".join(values)
+
+    node.query(f"INSERT INTO {table_name} VALUES {values}")
+
+
 insert_values = (
     " ('data1', 1, 0),"
     " ('data1', 2, 0),"

--- a/engines/tests/steps/__init__.py
+++ b/engines/tests/steps/__init__.py
@@ -1,0 +1,9 @@
+from .inserts import (
+    insert_values_into_table,
+    insert_values,
+)
+
+__all__ = [
+    "insert_values_into_table",
+    "insert_values",
+]

--- a/engines/tests/steps/inserts.py
+++ b/engines/tests/steps/inserts.py
@@ -1,9 +1,5 @@
-import time
-import random
-from helpers.common import getuid
 from testflows.core import *
-from helpers.common import create_xml_config_content, add_config
-from helpers.common import getuid, instrument_clickhouse_server_log
+
 
 @TestStep(When)
 def insert_values_into_table(self, table_name, values, node=None):

--- a/engines/tests/summing_merge_tree/steps/__init__.py
+++ b/engines/tests/summing_merge_tree/steps/__init__.py
@@ -1,0 +1,7 @@
+from .tables import create_summing_test_table
+from .inserts import insert_sample_values
+
+__all__ = [
+    "create_summing_test_table",
+    "insert_sample_values",
+]

--- a/engines/tests/summing_merge_tree/steps/inserts.py
+++ b/engines/tests/summing_merge_tree/steps/inserts.py
@@ -1,0 +1,15 @@
+from testflows.core import *
+
+from engines.tests.steps import insert_values_into_table
+
+
+@TestStep(When)
+def insert_sample_values(self, table_name, node=None):
+    """Insert the standard pair of sample rows used by the SummingMergeTree
+    scenarios: ``(1, 1, 100)`` and ``(2, 2, 200)``.
+    """
+    insert_values_into_table(
+        table_name=table_name,
+        values=["(1, 1, 100)", "(2, 2, 200)"],
+        node=node,
+    )

--- a/engines/tests/summing_merge_tree/steps/tables.py
+++ b/engines/tests/summing_merge_tree/steps/tables.py
@@ -1,0 +1,22 @@
+from testflows.core import *
+
+from helpers.create import create_summing_merge_tree_table
+
+
+@TestStep(Given)
+def create_summing_test_table(self, table_name, columns_to_sum=None):
+    """Create a SummingMergeTree table with the standard test schema
+    used across the SummingMergeTree scenarios: columns (v, p, c) of UInt64,
+    partitioned by ``p`` and ordered by ``v``.
+    """
+    create_summing_merge_tree_table(
+        table_name=table_name,
+        columns=[
+            {"name": "v", "type": "UInt64"},
+            {"name": "p", "type": "UInt64"},
+            {"name": "c", "type": "UInt64"},
+        ],
+        partition_by="p",
+        order_by="v",
+        columns_to_sum=columns_to_sum,
+    )

--- a/engines/tests/summing_merge_tree/summing_merge_tree.py
+++ b/engines/tests/summing_merge_tree/summing_merge_tree.py
@@ -2,6 +2,7 @@ import sys
 
 from testflows.core import *
 
+from engines.requirements import *
 from engines.tests.summing_merge_tree.steps import (
     create_summing_test_table,
     insert_sample_values,
@@ -15,6 +16,7 @@ append_path(sys.path, "..")
 
 
 @TestScenario
+@Requirements(RQ_SRS_046_ClickHouse_SummingMergeTree_ZeroRowDeletion_Update("1.0"))
 def zero_row_deletion_with_update(self, node=None):
     """Check that SummingMergeTree deletes rows where all summed columns
     are zero after UPDATE and OPTIMIZE TABLE FINAL."""
@@ -47,6 +49,7 @@ def zero_row_deletion_with_update(self, node=None):
 
 
 @TestScenario
+@Requirements(RQ_SRS_046_ClickHouse_SummingMergeTree_ZeroRowDeletion_ClearColumn("1.0"))
 def zero_row_deletion_with_clear_column(self, node=None):
     """Check that SummingMergeTree deletes rows where all summed columns
     are zero after CLEAR COLUMN IN PARTITION and OPTIMIZE TABLE FINAL.
@@ -81,6 +84,7 @@ def zero_row_deletion_with_clear_column(self, node=None):
 
 
 @TestScenario
+@Requirements(RQ_SRS_046_ClickHouse_SummingMergeTree_ClearColumn_Consistency("1.0"))
 def clear_column_validation_consistency(self, node=None):
     """Check that CLEAR COLUMN on summing columns is allowed consistently
     for both explicit and auto-detected ``columns_to_sum``.

--- a/engines/tests/summing_merge_tree/summing_merge_tree.py
+++ b/engines/tests/summing_merge_tree/summing_merge_tree.py
@@ -1,0 +1,141 @@
+import sys
+
+from testflows.core import *
+from engines.tests.steps import *
+from helpers.common import check_clickhouse_version
+
+append_path(sys.path, "..")
+
+
+@TestScenario
+def zero_row_deletion_with_update(self, node=None):
+    """Check that SummingMergeTree deletes rows where all summed columns
+    are zero after UPDATE and OPTIMIZE TABLE FINAL."""
+
+    if node is None:
+        node = self.context.cluster.node("clickhouse1")
+
+    name = f"summing_zero_update_{getuid()}"
+
+    try:
+        with Given("I create SummingMergeTree table with partition key"):
+            node.query(
+                f"CREATE TABLE {name} (v UInt64, p UInt64, c UInt64)"
+                f" ENGINE = SummingMergeTree PARTITION BY p ORDER BY v"
+            )
+
+        with When("I insert data"):
+            node.query(f"INSERT INTO {name} VALUES (1, 1, 100)")
+            node.query(f"INSERT INTO {name} VALUES (2, 2, 200)")
+
+        with And("I update summing column to zero"):
+            node.query(f"ALTER TABLE {name} UPDATE c = 0 WHERE v = 1")
+
+        with And("I optimize table"):
+            node.query(f"OPTIMIZE TABLE {name} FINAL")
+
+        with Then("row with all summed columns = 0 should be deleted"):
+            node.query(
+                f"SELECT count() FROM {name} FORMAT TabSeparated",
+                message="1",
+            )
+
+    finally:
+        with Finally("I drop table"):
+            node.query(f"DROP TABLE IF EXISTS {name}")
+
+
+@TestScenario
+def zero_row_deletion_with_clear_column(self, node=None):
+    """Check that SummingMergeTree deletes rows where all summed columns
+    are zero after CLEAR COLUMN IN PARTITION and OPTIMIZE TABLE FINAL.
+
+    Related: https://github.com/ClickHouse/ClickHouse/issues/101953
+    """
+
+    if node is None:
+        node = self.context.cluster.node("clickhouse1")
+
+    name = f"summing_zero_clear_{getuid()}"
+
+    try:
+        with Given("I create SummingMergeTree table with partition key"):
+            node.query(
+                f"CREATE TABLE {name} (v UInt64, p UInt64, c UInt64)"
+                f" ENGINE = SummingMergeTree PARTITION BY p ORDER BY v"
+            )
+
+        with When("I insert data"):
+            node.query(f"INSERT INTO {name} VALUES (1, 1, 100)")
+            node.query(f"INSERT INTO {name} VALUES (2, 2, 200)")
+
+        with And("I clear summing column in partition 1"):
+            node.query(f"ALTER TABLE {name} CLEAR COLUMN c IN PARTITION 1")
+
+        with And("I optimize table"):
+            node.query(f"OPTIMIZE TABLE {name} FINAL")
+
+        with Then("row with all summed columns = 0 should be deleted"):
+            node.query(
+                f"SELECT count() FROM {name} FORMAT TabSeparated",
+                message="1",
+            )
+
+    finally:
+        with Finally("I drop table"):
+            node.query(f"DROP TABLE IF EXISTS {name}")
+
+
+@TestScenario
+def clear_column_validation_consistency(self, node=None):
+    """Check that CLEAR COLUMN on auto-detected summing columns is
+    blocked the same way as explicitly declared ones.
+
+    Related: https://github.com/ClickHouse/ClickHouse/issues/101953
+    """
+
+    if node is None:
+        node = self.context.cluster.node("clickhouse1")
+
+    name_explicit = f"summing_explicit_{getuid()}"
+    name_auto = f"summing_auto_{getuid()}"
+
+    try:
+        with Given("I create table with explicit columns_to_sum"):
+            node.query(
+                f"CREATE TABLE {name_explicit} (v UInt64, p UInt64, c UInt64)"
+                f" ENGINE = SummingMergeTree(c) PARTITION BY p ORDER BY v"
+            )
+
+        with And("I create table with auto-detected columns_to_sum"):
+            node.query(
+                f"CREATE TABLE {name_auto} (v UInt64, p UInt64, c UInt64)"
+                f" ENGINE = SummingMergeTree PARTITION BY p ORDER BY v"
+            )
+
+        with When("I try to clear summing column on explicit table"):
+            node.query(
+                f"ALTER TABLE {name_explicit} CLEAR COLUMN c IN PARTITION 1",
+                exitcode=524,
+                message="ALTER_OF_COLUMN_IS_FORBIDDEN",
+            )
+
+        with Then("I try to clear summing column on auto-detected table"):
+            node.query(
+                f"ALTER TABLE {name_auto} CLEAR COLUMN c IN PARTITION 1",
+                exitcode=524,
+                message="ALTER_OF_COLUMN_IS_FORBIDDEN",
+            )
+
+    finally:
+        with Finally("I drop tables"):
+            node.query(f"DROP TABLE IF EXISTS {name_explicit}")
+            node.query(f"DROP TABLE IF EXISTS {name_auto}")
+
+
+@TestModule
+@Name("summing_merge_tree")
+def feature(self):
+    """SummingMergeTree engine tests."""
+    for scenario in loads(current_module(), Scenario):
+        scenario()

--- a/engines/tests/summing_merge_tree/summing_merge_tree.py
+++ b/engines/tests/summing_merge_tree/summing_merge_tree.py
@@ -1,11 +1,15 @@
 import sys
 
 from testflows.core import *
-from engines.tests.steps import *
-from helpers.common import check_clickhouse_version
-from helpers.create import create_summing_merge_tree_table
-from helpers.alter.update import alter_table_update_column
+
+from engines.tests.summing_merge_tree.steps import (
+    create_summing_test_table,
+    insert_sample_values,
+)
 from helpers.alter.column import alter_table_clear_column_in_partition
+from helpers.alter.update import alter_table_update_column
+from helpers.common import getuid
+from helpers.queries import optimize, assert_row_count
 
 append_path(sys.path, "..")
 
@@ -20,46 +24,26 @@ def zero_row_deletion_with_update(self, node=None):
 
     name = f"summing_zero_update_{getuid()}"
 
-    try:
-        with Given("I create SummingMergeTree table with partition key"):
-            create_summing_merge_tree_table(
-                table_name=name,
-                columns=[
-                    {"name": "v", "type": "UInt64"}, 
-                    {"name": "p", "type": "UInt64"}, 
-                    {"name": "c", "type": "UInt64"}, 
-                ],
-                partition_by="p",
-                order_by="v",
-            )
+    with Given("I create SummingMergeTree table with partition key"):
+        create_summing_test_table(table_name=name)
 
-        with When("I insert data"):
-            insert_values_into_table(
-                table_name=name,
-                values=["(1, 1, 100)", "(2, 2, 200)"],
-            )
+    with When("I insert data"):
+        insert_sample_values(table_name=name, node=node)
 
-        with And("I update summing column to zero"):
-            alter_table_update_column(
-                table_name=name,
-                column_name="c",
-                expression="0",
-                condition="v = 1",
-                node=node,
-            )
+    with And("I update summing column to zero"):
+        alter_table_update_column(
+            table_name=name,
+            column_name="c",
+            expression="0",
+            condition="v = 1",
+            node=node,
+        )
 
-        with And("I optimize table"):
-            node.query(f"OPTIMIZE TABLE {name} FINAL")
+    with And("I optimize table"):
+        optimize(node=node, table_name=name, final=True)
 
-        with Then("row with all summed columns = 0 should be deleted"):
-            node.query(
-                f"SELECT count() FROM {name} FORMAT TabSeparated",
-                message="1",
-            )
-
-    finally:
-        with Finally("I drop table"):
-            node.query(f"DROP TABLE IF EXISTS {name}")
+    with Then("row with all summed columns = 0 should be deleted"):
+        assert_row_count(node=node, table_name=name, rows=1)
 
 
 @TestScenario
@@ -75,45 +59,25 @@ def zero_row_deletion_with_clear_column(self, node=None):
 
     name = f"summing_zero_clear_{getuid()}"
 
-    try:
-        with Given("I create SummingMergeTree table with partition key"):
-            create_summing_merge_tree_table(
-                table_name=name,
-                columns=[
-                    {"name": "v", "type": "UInt64"},
-                    {"name": "p", "type": "UInt64"},
-                    {"name": "c", "type": "UInt64"},
-                ],
-                partition_by="p",
-                order_by="v",
-            )
+    with Given("I create SummingMergeTree table with partition key"):
+        create_summing_test_table(table_name=name)
 
-        with When("I insert data"):
-            insert_values_into_table(
-                table_name=name,
-                values=["(1, 1, 100)", "(2, 2, 200)"],
-            )
+    with When("I insert data"):
+        insert_sample_values(table_name=name, node=node)
 
-        with And("I clear summing column in partition 1"):
-            alter_table_clear_column_in_partition(
-                table_name=name,
-                partition_name="1",
-                column_name="c",
-                node=node,
-            )
+    with And("I clear summing column in partition 1"):
+        alter_table_clear_column_in_partition(
+            table_name=name,
+            partition_name="1",
+            column_name="c",
+            node=node,
+        )
 
-        with And("I optimize table"):
-            node.query(f"OPTIMIZE TABLE {name} FINAL")
+    with And("I optimize table"):
+        optimize(node=node, table_name=name, final=True)
 
-        with Then("row with all summed columns = 0 should be deleted"):
-            node.query(
-                f"SELECT count() FROM {name} FORMAT TabSeparated",
-                message="1",
-            )
-
-    finally:
-        with Finally("I drop table"):
-            node.query(f"DROP TABLE IF EXISTS {name}")
+    with Then("row with all summed columns = 0 should be deleted"):
+        assert_row_count(node=node, table_name=name, rows=1)
 
 
 @TestScenario
@@ -130,50 +94,27 @@ def clear_column_validation_consistency(self, node=None):
     name_explicit = f"summing_explicit_{getuid()}"
     name_auto = f"summing_auto_{getuid()}"
 
-    try:
-        columns = [
-            {"name": "v", "type": "UInt64"},
-            {"name": "p", "type": "UInt64"},
-            {"name": "c", "type": "UInt64"},
-        ]
+    with Given("I create table with explicit columns_to_sum"):
+        create_summing_test_table(table_name=name_explicit, columns_to_sum=["c"])
 
-        with Given("I create table with explicit columns_to_sum"):
-            create_summing_merge_tree_table(
-                table_name=name_explicit,
-                columns=columns,
-                partition_by="p",
-                order_by="v",
-                columns_to_sum=["c"],
-            )
+    with And("I create table with auto-detected columns_to_sum"):
+        create_summing_test_table(table_name=name_auto)
 
-        with And("I create table with auto-detected columns_to_sum"):
-            create_summing_merge_tree_table(
-                table_name=name_auto,
-                columns=columns,
-                partition_by="p",
-                order_by="v",
-            )
+    with When("I clear summing column on explicit table"):
+        alter_table_clear_column_in_partition(
+            table_name=name_explicit,
+            partition_name="1",
+            column_name="c",
+            node=node,
+        )
 
-        with When("I clear summing column on explicit table"):
-            alter_table_clear_column_in_partition(
-                table_name=name_explicit,
-                partition_name="1",
-                column_name="c",
-                node=node,
-            )
-
-        with Then("I clear summing column on auto-detected table"):
-            alter_table_clear_column_in_partition(
-                table_name=name_auto,
-                partition_name="1",
-                column_name="c",
-                node=node,
-            )
-
-    finally:
-        with Finally("I drop tables"):
-            node.query(f"DROP TABLE IF EXISTS {name_explicit}")
-            node.query(f"DROP TABLE IF EXISTS {name_auto}")
+    with Then("I clear summing column on auto-detected table"):
+        alter_table_clear_column_in_partition(
+            table_name=name_auto,
+            partition_name="1",
+            column_name="c",
+            node=node,
+        )
 
 
 @TestModule

--- a/engines/tests/summing_merge_tree/summing_merge_tree.py
+++ b/engines/tests/summing_merge_tree/summing_merge_tree.py
@@ -3,6 +3,9 @@ import sys
 from testflows.core import *
 from engines.tests.steps import *
 from helpers.common import check_clickhouse_version
+from helpers.create import create_summing_merge_tree_table
+from helpers.alter.update import alter_table_update_column
+from helpers.alter.column import alter_table_clear_column_in_partition
 
 append_path(sys.path, "..")
 
@@ -19,17 +22,31 @@ def zero_row_deletion_with_update(self, node=None):
 
     try:
         with Given("I create SummingMergeTree table with partition key"):
-            node.query(
-                f"CREATE TABLE {name} (v UInt64, p UInt64, c UInt64)"
-                f" ENGINE = SummingMergeTree PARTITION BY p ORDER BY v"
+            create_summing_merge_tree_table(
+                table_name=name,
+                columns=[
+                    {"name": "v", "type": "UInt64"}, 
+                    {"name": "p", "type": "UInt64"}, 
+                    {"name": "c", "type": "UInt64"}, 
+                ],
+                partition_by="p",
+                order_by="v",
             )
 
         with When("I insert data"):
-            node.query(f"INSERT INTO {name} VALUES (1, 1, 100)")
-            node.query(f"INSERT INTO {name} VALUES (2, 2, 200)")
+            insert_values_into_table(
+                table_name=name,
+                values=["(1, 1, 100)", "(2, 2, 200)"],
+            )
 
         with And("I update summing column to zero"):
-            node.query(f"ALTER TABLE {name} UPDATE c = 0 WHERE v = 1")
+            alter_table_update_column(
+                table_name=name,
+                column_name="c",
+                expression="0",
+                condition="v = 1",
+                node=node,
+            )
 
         with And("I optimize table"):
             node.query(f"OPTIMIZE TABLE {name} FINAL")
@@ -60,17 +77,30 @@ def zero_row_deletion_with_clear_column(self, node=None):
 
     try:
         with Given("I create SummingMergeTree table with partition key"):
-            node.query(
-                f"CREATE TABLE {name} (v UInt64, p UInt64, c UInt64)"
-                f" ENGINE = SummingMergeTree PARTITION BY p ORDER BY v"
+            create_summing_merge_tree_table(
+                table_name=name,
+                columns=[
+                    {"name": "v", "type": "UInt64"},
+                    {"name": "p", "type": "UInt64"},
+                    {"name": "c", "type": "UInt64"},
+                ],
+                partition_by="p",
+                order_by="v",
             )
 
         with When("I insert data"):
-            node.query(f"INSERT INTO {name} VALUES (1, 1, 100)")
-            node.query(f"INSERT INTO {name} VALUES (2, 2, 200)")
+            insert_values_into_table(
+                table_name=name,
+                values=["(1, 1, 100)", "(2, 2, 200)"],
+            )
 
         with And("I clear summing column in partition 1"):
-            node.query(f"ALTER TABLE {name} CLEAR COLUMN c IN PARTITION 1")
+            alter_table_clear_column_in_partition(
+                table_name=name,
+                partition_name="1",
+                column_name="c",
+                node=node,
+            )
 
         with And("I optimize table"):
             node.query(f"OPTIMIZE TABLE {name} FINAL")
@@ -88,8 +118,8 @@ def zero_row_deletion_with_clear_column(self, node=None):
 
 @TestScenario
 def clear_column_validation_consistency(self, node=None):
-    """Check that CLEAR COLUMN on auto-detected summing columns is
-    blocked the same way as explicitly declared ones.
+    """Check that CLEAR COLUMN on summing columns is allowed consistently
+    for both explicit and auto-detected ``columns_to_sum``.
 
     Related: https://github.com/ClickHouse/ClickHouse/issues/101953
     """
@@ -101,30 +131,43 @@ def clear_column_validation_consistency(self, node=None):
     name_auto = f"summing_auto_{getuid()}"
 
     try:
+        columns = [
+            {"name": "v", "type": "UInt64"},
+            {"name": "p", "type": "UInt64"},
+            {"name": "c", "type": "UInt64"},
+        ]
+
         with Given("I create table with explicit columns_to_sum"):
-            node.query(
-                f"CREATE TABLE {name_explicit} (v UInt64, p UInt64, c UInt64)"
-                f" ENGINE = SummingMergeTree(c) PARTITION BY p ORDER BY v"
+            create_summing_merge_tree_table(
+                table_name=name_explicit,
+                columns=columns,
+                partition_by="p",
+                order_by="v",
+                columns_to_sum=["c"],
             )
 
         with And("I create table with auto-detected columns_to_sum"):
-            node.query(
-                f"CREATE TABLE {name_auto} (v UInt64, p UInt64, c UInt64)"
-                f" ENGINE = SummingMergeTree PARTITION BY p ORDER BY v"
+            create_summing_merge_tree_table(
+                table_name=name_auto,
+                columns=columns,
+                partition_by="p",
+                order_by="v",
             )
 
-        with When("I try to clear summing column on explicit table"):
-            node.query(
-                f"ALTER TABLE {name_explicit} CLEAR COLUMN c IN PARTITION 1",
-                exitcode=524,
-                message="ALTER_OF_COLUMN_IS_FORBIDDEN",
+        with When("I clear summing column on explicit table"):
+            alter_table_clear_column_in_partition(
+                table_name=name_explicit,
+                partition_name="1",
+                column_name="c",
+                node=node,
             )
 
-        with Then("I try to clear summing column on auto-detected table"):
-            node.query(
-                f"ALTER TABLE {name_auto} CLEAR COLUMN c IN PARTITION 1",
-                exitcode=524,
-                message="ALTER_OF_COLUMN_IS_FORBIDDEN",
+        with Then("I clear summing column on auto-detected table"):
+            alter_table_clear_column_in_partition(
+                table_name=name_auto,
+                partition_name="1",
+                column_name="c",
+                node=node,
             )
 
     finally:

--- a/helpers/create.py
+++ b/helpers/create.py
@@ -210,12 +210,17 @@ def create_summing_merge_tree_table(
     partition_by: str = None,
     cluster: str = None,
     stop_merges: bool = False,
+    columns_to_sum: list[str] = None,
 ):
     """Create a table with the SummingMergeTree engine."""
+    engine = "SummingMergeTree"
+    if columns_to_sum:
+        engine = f"SummingMergeTree({', '.join(columns_to_sum)})"
+
     create_table(
         table_name=table_name,
         columns=columns,
-        engine="SummingMergeTree",
+        engine=engine,
         order_by=order_by,
         primary_key=primary_key,
         if_not_exists=if_not_exists,

--- a/helpers/queries.py
+++ b/helpers/queries.py
@@ -5,6 +5,7 @@ Helpers.queries contains functions that wrap SQL queries.
 import json
 
 from testflows.core import *
+from testflows.asserts import error
 from testflows.uexpect.uexpect import ExpectTimeoutError
 from testflows.connect.shell import Command
 
@@ -108,7 +109,7 @@ def optimize(
     self, node: ClickHouseNode, table_name: str, final=False, no_checks=False
 ) -> Command:
     """Apply OPTIMIZE on the given table and node."""
-    q = f"OPTIMIZE TABLE {table_name}" + " FINAL" if final else ""
+    q = f"OPTIMIZE TABLE {table_name}" + (" FINAL" if final else "")
     return node.query(q, no_checks=no_checks, exitcode=0)
 
 
@@ -167,6 +168,18 @@ def get_row_count(
         timeout=timeout,
     )
     return int(json.loads(r.output)[0])
+
+
+@TestStep(Then)
+def assert_row_count(
+    self, table_name: str, rows: int, node: ClickHouseNode = None, timeout: int = 30
+) -> None:
+    """Assert that the number of rows in a table matches the expected value."""
+    if node is None:
+        node = self.context.node
+
+    actual_count = get_row_count(node=node, table_name=table_name, timeout=timeout)
+    assert actual_count == rows, error()
 
 
 @TestStep


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                               
                                                          
- Add engines/tests/summing_merge_tree/ test suite covering SummingMergeTree zero-row deletion behavior                                                                                                                                               
- Tests cover the regression found in ClickHouse upstream: https://github.com/ClickHouse/ClickHouse/issues/101953
- Two scenarios xfailed pending upstream fix:                                                                                                                                                                                                         
  - CLEAR COLUMN IN PARTITION does not trigger zero-row deletion after OPTIMIZE TABLE FINAL (regression since 25.8)                                                                                                                                   
  - CLEAR COLUMN validation inconsistency between explicit and auto-detected summing columns                                                                                                                                                          
                                                                                                                                                                                                                                                      
Test plan                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                      
- zero_row_deletion_with_update — passes on all versions                                                                                                                                                                                              
- zero_row_deletion_with_clear_column — xfail on >=25.8 (upstream issue)
- clear_column_validation_consistency — xfail on all versions (upstream issue)