### PR TITLE
fix(rbac): prevent log rotation breakage in multiple_auth_methods restarts

### DIFF
--- a/helpers/common.py
+++ b/helpers/common.py
@@ -799,6 +799,18 @@ def add_config(
             with And("I start ClickHouse back up"):
                 node.start_clickhouse(user=user, wait_healthy=wait_healthy)
 
+            with And("I detect if the log file was rotated during restart"):
+                cmd = node.cluster.command(
+                    None,
+                    f"stat -c %s {cluster.environ['CLICKHOUSE_TESTS_DIR']}/_instances/{node.name}/logs/clickhouse-server.log",
+                )
+                current_logsize = cmd.output.split(" ")[0].strip()
+                if int(current_logsize) < int(logsize):
+                    # Log rotated while server was restarting: captured offset is
+                    # past the new file's EOF. Reset to byte 1 so tail reads from
+                    # the start of the new file.
+                    logsize = "1"
+
             with Then("I tail the log file from using previous log size as the offset"):
                 bash.prompt = bash.__class__.prompt
                 bash.open()
@@ -954,6 +966,18 @@ def remove_config(
 
             with And("I start ClickHouse back up"):
                 node.start_clickhouse(user=user, wait_healthy=wait_healthy)
+
+            with And("I detect if the log file was rotated during restart"):
+                cmd = node.cluster.command(
+                    None,
+                    f"stat -c %s {cluster.environ['CLICKHOUSE_TESTS_DIR']}/_instances/{node.name}/logs/clickhouse-server.log",
+                )
+                current_logsize = cmd.output.split(" ")[0].strip()
+                if int(current_logsize) < int(logsize):
+                    # Log rotated while server was restarting: captured offset is
+                    # past the new file's EOF. Reset to byte 1 so tail reads from
+                    # the start of the new file.
+                    logsize = "1"
 
             with Then("I tail the log file from using previous log size as the offset"):
                 bash.prompt = bash.__class__.prompt

--- a/rbac/configs/clickhouse/config.d/logs.xml
+++ b/rbac/configs/clickhouse/config.d/logs.xml
@@ -4,7 +4,7 @@
         <level>trace</level>
         <log>/var/log/clickhouse-server/log.log</log>
         <errorlog>/var/log/clickhouse-server/log.err.log</errorlog>
-        <size>1000M</size>
+        <size>2000M</size>
         <count>10</count>
         <stderr>/var/log/clickhouse-server/stderr.log</stderr>
         <stdout>/var/log/clickhouse-server/stdout.log</stdout>
@@ -12,6 +12,6 @@
     <part_log>
         <database>system</database>
         <table>part_log</table>
-        <flush_interval_milliseconds>500</flush_interval_milliseconds>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </part_log>
 </clickhouse>

--- a/rbac/configs/clickhouse/config.d/logs.xml
+++ b/rbac/configs/clickhouse/config.d/logs.xml
@@ -12,6 +12,6 @@
     <part_log>
         <database>system</database>
         <table>part_log</table>
-        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <flush_interval_milliseconds>500</flush_interval_milliseconds>
     </part_log>
 </clickhouse>

--- a/rbac/configs/clickhouse/config.d/logs.xml
+++ b/rbac/configs/clickhouse/config.d/logs.xml
@@ -12,6 +12,6 @@
     <part_log>
         <database>system</database>
         <table>part_log</table>
-        <flush_interval_milliseconds>500</flush_interval_milliseconds>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
     </part_log>
 </clickhouse>


### PR DESCRIPTION
The /rbac/part 3/multiple authentication methods/ feature performs 60-70 server restarts per run (each change_server_settings call defaults to restart=True), and each restart relies
on helpers/common.py::wait_for_config_to_be_loaded waiting for the "Loaded config performed update on configuration" log line via `tail -c +{offset} -f`. When the cumulative log
volume crosses the 1000M rotation threshold configured in logs.xml, ClickHouse rotates the log file mid-restart: the captured offset lands past the new file's EOF, tail produces no
output for the full 5-min timeout, and the test fails with ExpectTimeoutError even though ConfigReloader emits the expected line normally. This was reproducible across antalya-26.3
and upstream 26.4+ on x86 CI runners.

Fix in three parts, each justifiable on its own:
- make `wait_for_config_to_be_loaded` rotation-aware (re-stat after restart and reset offset to 1 if the file shrank);
- raise `<size>` from 1000M to 2000M to make rotation during a run statistically rare;
- revert `flush_interval_milliseconds` for system.part_log to the upstream default 7500ms (no rbac test queries system.part_log, so the 500ms copy-paste value was load with no benefit).

Validated with 12 consecutive successful reruns.