### PR TITLE
s3: derive the docker network from the container in reconnect tests

### DIFF
--- a/helpers/cluster.py
+++ b/helpers/cluster.py
@@ -1816,6 +1816,33 @@ class Cluster(object):
                 time.sleep(1)
         return container_id
 
+    def node_container_network(self, node=None, container_id=None, timeout=300):
+        """Return the name of the docker network a service's container is attached to.
+
+        Must be called with self.lock acquired.
+        """
+        if container_id is None:
+            if node is None:
+                raise TypeError("either node or container_id must be specified")
+            container_id = self.node_container_id(node=node, timeout=timeout)
+
+        c = self.control_shell(
+            "docker inspect --format "
+            "'{{range $net, $conf := .NetworkSettings.Networks}}{{$net}} {{end}}' "
+            f"{container_id}",
+            timeout=timeout,
+        )
+
+        networks = c.output.split() if c.exitcode == 0 else []
+
+        if not networks:
+            raise RuntimeError(
+                f"failed to get the docker network of the "
+                f"{node if node is not None else container_id} container"
+            )
+
+        return networks[0]
+
     def shell(self, node, timeout=300):
         """Returns unique shell terminal to be used."""
         container_id = None

--- a/s3/tests/reconnect.py
+++ b/s3/tests/reconnect.py
@@ -1,10 +1,18 @@
-from platform import processor
-
 from s3.tests.common import *
 from s3.requirements import *
 from lightweight_delete.tests.steps import *
 
-DOCKER_NETWORK = "s3_env_default" if processor() == "x86_64" else "s3_env_arm64"
+
+@TestStep(Given)
+def container_and_network(self, node_name):
+    """Return the container id and the docker network name of a cluster node."""
+    cluster = self.context.cluster
+
+    with cluster.lock:
+        container_id = cluster.node_container_id(node=node_name)
+        network = cluster.node_container_network(container_id=container_id)
+
+    return container_id, network
 
 
 @TestStep(When)
@@ -13,14 +21,17 @@ def disconnect_reconnect(self, node=None):
     if node is None:
         node = self.context.node
 
+    with Given("I get the container id and network name"):
+        container_id, network = container_and_network(node_name=node.name)
+
     with When("I disconnect the docker node"):
         self.context.cluster.command(
-            None, f"docker network disconnect {DOCKER_NETWORK} s3_env_clickhouse1_1"
+            None, f"docker network disconnect --force {network} {container_id}"
         )
 
     with And("I reconnect the docker node"):
         self.context.cluster.command(
-            None, f"docker network connect {DOCKER_NETWORK} s3_env_clickhouse1_1"
+            None, f"docker network connect {network} {container_id}"
         )
 
 
@@ -38,22 +49,19 @@ def automatic_reconnection(self, policy_name, disk_name="external", node=None):
     with When("I insert some data into the table"):
         node.query(f"INSERT INTO {table_name} VALUES (1, 2)")
 
-    with And("I get container id and network id"):
-        container_id = self.context.cluster.node_container_id(node="clickhouse1")
-        network_id = self.context.cluster.command(
-            None, f"docker network ls --filter 'name={DOCKER_NETWORK}' -q"
-        ).output
+    with And("I get container id and network name"):
+        container_id, network = container_and_network(node_name=node.name)
 
     with And("I stop the connection to the node with the table"):
         self.context.cluster.command(
-            None, f"docker network disconnect --force {network_id} {container_id}"
+            None, f"docker network disconnect --force {network} {container_id}"
         )
 
     time.sleep(5)
 
     with And("I enable the connection to the node with the table"):
         self.context.cluster.command(
-            None, f"docker network connect {network_id} {container_id}"
+            None, f"docker network connect {network} {container_id}"
         )
 
     with Then("I check the table"):


### PR DESCRIPTION
The previous way of recovering/guessing the network name doesn't work in all environments.
This commit implements a more portable way of obtaining the real name.