### PR TITLE
Wait for mutation to complete to reduce flakyness

### DIFF
--- a/s3/tests/alter.py
+++ b/s3/tests/alter.py
@@ -11,6 +11,7 @@ from helpers.common import getuid, check_clickhouse_version
 from s3.tests.common import (
     default_s3_disk_and_volume,
     assert_row_count,
+    wait_for_all_mutations_to_complete,
     insert_random,
     temporary_bucket_path,
     s3_storage,
@@ -169,6 +170,11 @@ def index(self):
             )
 
     with Check("clear"):
+        with Given("the materialize mutation has finished"):
+            wait_for_all_mutations_to_complete(
+                node=nodes[0], table_name=table_name, **retry_args
+            )
+
         with When("I clear an index"):
             retry(nodes[0].query, **retry_args)(
                 f"ALTER TABLE {table_name} CLEAR INDEX idx_test",

--- a/s3/tests/common.py
+++ b/s3/tests/common.py
@@ -1835,6 +1835,29 @@ def assert_row_count(self, node, table_name: str, rows: int = 1000000):
     assert rows == actual_count, error()
 
 
+@TestStep(When)
+def wait_for_all_mutations_to_complete(
+    self, node=None, table_name=None, timeout=30, delay=1
+):
+    """Wait for all mutations to complete on a given node."""
+    if node is None:
+        node = self.context.node
+
+    if table_name is None:
+        query = "SELECT count() FROM system.mutations WHERE is_done = 0"
+    else:
+        query = f"SELECT count() FROM system.mutations WHERE table = '{table_name}' AND is_done = 0"
+
+    for attempt in retries(timeout=timeout, delay=delay):
+        with attempt:
+            pending_mutations = node.query(
+                query,
+                exitcode=0,
+                steps=True,
+            ).output.strip()
+            assert int(pending_mutations) == 0, error()
+
+
 @TestStep(Then)
 def check_consistency(self, nodes, table_name, sync_timeout=10):
     """SYNC the given nodes and check that they agree about the given table"""

--- a/s3/tests/export_part/steps.py
+++ b/s3/tests/export_part/steps.py
@@ -6,7 +6,11 @@ from testflows.asserts import error
 from helpers.common import getuid
 from helpers.create import *
 from helpers.queries import *
-from s3.tests.common import temporary_bucket_path, s3_storage
+from s3.tests.common import (
+    temporary_bucket_path,
+    s3_storage,
+    wait_for_all_mutations_to_complete,
+)
 from helpers.alter import *
 from helpers.cluster import MESSAGES_TO_RETRY
 from platform import processor
@@ -340,27 +344,6 @@ def get_random_part(self, table_name, node=None, partition=None):
         steps=True,
     )
     return result.output.strip()
-
-
-@TestStep(When)
-def wait_for_all_mutations_to_complete(self, node=None, table_name=None):
-    """Wait for all mutations to complete on a given node."""
-    if node is None:
-        node = self.context.node
-
-    if table_name is None:
-        query = "SELECT count() FROM system.mutations WHERE is_done = 0"
-    else:
-        query = f"SELECT count() FROM system.mutations WHERE table = '{table_name}' AND is_done = 0"
-
-    for attempt in retries(timeout=30, delay=1):
-        with attempt:
-            pending_mutations = node.query(
-                query,
-                exitcode=0,
-                steps=True,
-            ).output.strip()
-            assert int(pending_mutations) == 0, error()
 
 
 @TestStep(When)


### PR DESCRIPTION
MODIFY ORDER BY test on S3 has proven a bit flaky.
Explicitly waiting for mutations to complete fixes it.