### PR TITLE
alter_replace: fix tests exposed by the 26.6 empty-source guard

### DIFF
--- a/alter/table/replace_partition/common.py
+++ b/alter/table/replace_partition/common.py
@@ -10,26 +10,6 @@ from helpers.tables import create_table_partitioned_by_column, create_table, Col
 
 
 @TestStep(Given)
-def create_partitions_for_collapsing_merge_tree(
-    self,
-    table_name,
-    number_of_values=3,
-    number_of_partitions=5,
-    number_of_parts=1,
-    node=None,
-):
-    """Insert random UInt64 values into a column and create multiple partitions based on the value of number_of_partitions."""
-    if node is None:
-        node = self.context.node
-
-    with By("Inserting random values into a column with uint64 datatype"):
-        for i in range(1, number_of_partitions + 1):
-            for parts in range(1, number_of_parts + 1):
-                node.query(
-                    f"INSERT INTO {table_name} (p, i) SELECT {random.choice([-1, 1])}, rand64() FROM numbers({number_of_values})"
-                )
-
-@TestStep(Given)
 def create_partitions_with_random_uint64(
     self,
     table_name,
@@ -37,17 +17,21 @@ def create_partitions_with_random_uint64(
     number_of_partitions=5,
     number_of_parts=1,
     node=None,
-    from_partition=1
+    from_partition=1,
+    extra_columns=None,
 ):
     """Insert random UInt64 values into a column and create multiple partitions based on the value of number_of_partitions."""
     if node is None:
         node = self.context.node
 
+    names = ", " + ", ".join(extra_columns) if extra_columns else ""
+    values = ", " + ", ".join(extra_columns.values()) if extra_columns else ""
+
     with By("Inserting random values into a column with uint64 datatype"):
         for i in range(from_partition, from_partition + number_of_partitions):
             for parts in range(1, number_of_parts + 1):
                 node.query(
-                    f"INSERT INTO {table_name} (p, i) SELECT {i}, rand64() FROM numbers({number_of_values})"
+                    f"INSERT INTO {table_name} (p, i{names}) SELECT {i}, rand64(){values} FROM numbers({number_of_values})"
                 )
 
 

--- a/alter/table/replace_partition/common.py
+++ b/alter/table/replace_partition/common.py
@@ -19,8 +19,9 @@ def create_partitions_with_random_uint64(
     node=None,
     from_partition=1,
     extra_columns=None,
+    partition_values=None,
 ):
-    """Insert random UInt64 values into a column and create multiple partitions based on the value of number_of_partitions."""
+    """Insert random UInt64 values into a column and create multiple partitions based on the value of number_of_partitions"""
     if node is None:
         node = self.context.node
 
@@ -30,8 +31,9 @@ def create_partitions_with_random_uint64(
     with By("Inserting random values into a column with uint64 datatype"):
         for i in range(from_partition, from_partition + number_of_partitions):
             for parts in range(1, number_of_parts + 1):
+                partition = random.choice(partition_values) if partition_values else i
                 node.query(
-                    f"INSERT INTO {table_name} (p, i{names}) SELECT {i}, rand64(){values} FROM numbers({number_of_values})"
+                    f"INSERT INTO {table_name} (p, i{names}) SELECT {partition}, rand64(){values} FROM numbers({number_of_values})"
                 )
 
 

--- a/alter/table/replace_partition/concurrent_actions.py
+++ b/alter/table/replace_partition/concurrent_actions.py
@@ -1,5 +1,7 @@
 import random
 
+from testflows.asserts import error
+
 from alter.table.replace_partition.common import (
     create_two_tables_partitioned_by_column_with_data,
     replace_partition_and_validate_data,
@@ -896,6 +898,18 @@ def freeze_destination_and_source_partition_with_name(self):
     freeze_source_partition_with_name()
 
 
+def random_existing_partition(table_name, node):
+    """Pick at random a partition that currently has parts on the table."""
+    partitions = node.query(
+        f"SELECT DISTINCT partition FROM system.parts "
+        f"WHERE table = '{table_name}' AND active FORMAT TabSeparated"
+    ).output.split()
+
+    assert partitions, error(f"no partition with parts left on {table_name}")
+
+    return random.choice(partitions)
+
+
 @TestStep(When)
 def concurrent_replace_with_multiple_actions(
     self,
@@ -918,9 +932,11 @@ def concurrent_replace_with_multiple_actions(
         "running the replace partition number of times and each time run number of other actions in parallel"
     ):
         for i in range(number_of_iterations):
-            partition_to_replace = random.randrange(1, number_of_partitions)
             for retry in retries(timeout=60):
                 with retry:
+                    partition_to_replace = random_existing_partition(
+                        table_name=source_table, node=self.context.node
+                    )
                     Check(
                         name=f"replace partition on the destination table #{i}",
                         test=replace_partition_and_validate_data,

--- a/alter/table/replace_partition/concurrent_replace_partitions.py
+++ b/alter/table/replace_partition/concurrent_replace_partitions.py
@@ -24,7 +24,7 @@ def create_partitions_with_random_parts(self, table_name, number_of_partitions):
             with By(
                 f"creating {number_of_parts} parts inside the {partition} partition"
             ):
-                for parts in range(1, number_of_parts):
+                for parts in range(1, number_of_parts + 1):
                     node.query(
                         f"INSERT INTO {table_name} (p, i) SELECT {partition}, rand64() FROM numbers(10)"
                     )

--- a/alter/table/replace_partition/concurrent_replace_partitions_on_replicas.py
+++ b/alter/table/replace_partition/concurrent_replace_partitions_on_replicas.py
@@ -41,7 +41,7 @@ def create_partitions_with_random_parts(self, table_name, number_of_partitions):
             with By(
                 f"creating {number_of_parts} parts inside the {partition} partition"
             ):
-                for parts in range(1, number_of_parts):
+                for parts in range(1, number_of_parts + 1):
                     node.query(
                         f"INSERT INTO {table_name} (p, i) SELECT {partition}, rand64() FROM numbers(10)"
                     )

--- a/alter/table/replace_partition/data_integrity.py
+++ b/alter/table/replace_partition/data_integrity.py
@@ -74,7 +74,7 @@ def non_existent_partition(
                 source_table=source_table,
                 partition=partition_to_replace,
                 exitcode=36,
-                message="has no parts in partition",
+                message="DB::Exception: Source table",
             )
 
         with And("the data of the destination table is kept"):

--- a/alter/table/replace_partition/data_integrity.py
+++ b/alter/table/replace_partition/data_integrity.py
@@ -7,7 +7,7 @@ from alter.table.replace_partition.common import (
     create_table_partitioned_by_column_with_data,
 )
 from alter.table.replace_partition.requirements.requirements import *
-from helpers.common import getuid
+from helpers.common import getuid, replace_partition, check_clickhouse_version
 
 
 @TestScenario
@@ -39,6 +39,7 @@ def non_existent_partition(
     self, destination_partitions, source_partitions, partition_to_replace
 ):
     """Replace partition that does not exist either on the destination or the source table."""
+    node = self.context.node
     source_table = "source" + getuid()
     destination_table = "destination" + getuid()
 
@@ -54,14 +55,39 @@ def non_existent_partition(
             table_name=source_table, number_of_partitions=source_partitions
         )
 
-    with Then(
-        "I replace partition that does not exist on the destination table but exists on the source table"
-    ):
-        replace_partition_and_validate_data(
-            destination_table=destination_table,
-            source_table=source_table,
-            partition_to_replace=partition_to_replace,
+    source_partition_is_empty = partition_to_replace > source_partitions
+
+    if source_partition_is_empty and check_clickhouse_version(">=26.6")(self):
+        select_destination = (
+            f"SELECT i FROM {destination_table} WHERE p = {partition_to_replace} "
+            "ORDER BY tuple(*) FORMAT TabSeparated"
         )
+
+        with And("I save the data of the partition on the destination table"):
+            data_before = node.query(select_destination).output
+
+        with Then(
+            "replace partition is refused because the source partition has no parts"
+        ):
+            replace_partition(
+                destination_table=destination_table,
+                source_table=source_table,
+                partition=partition_to_replace,
+                exitcode=36,
+                message="has no parts in partition",
+            )
+
+        with And("the data of the destination table is kept"):
+            assert node.query(select_destination).output == data_before, error()
+    else:
+        with Then(
+            "I replace partition that does not exist on the destination table but exists on the source table"
+        ):
+            replace_partition_and_validate_data(
+                destination_table=destination_table,
+                source_table=source_table,
+                partition_to_replace=partition_to_replace,
+            )
 
 
 @TestScenario

--- a/alter/table/replace_partition/engines.py
+++ b/alter/table/replace_partition/engines.py
@@ -6,12 +6,11 @@ from alter.table.replace_partition.common import (
 )
 from alter.table.replace_partition.requirements.requirements import *
 from helpers.common import getuid, replace_partition
+from helpers import create
 from helpers.create import (
     partitioned_merge_tree_table,
     partitioned_replacing_merge_tree_table,
     partitioned_summing_merge_tree_table,
-    partitioned_collapsing_merge_tree_table,
-    partitioned_versioned_collapsing_merge_tree_table,
     partitioned_graphite_merge_tree_table,
     partitioned_aggregating_merge_tree_table,
     create_replicated_merge_tree_table,
@@ -21,7 +20,7 @@ from helpers.create import (
 @TestStep(Given)
 @Requirements(RQ_SRS_032_ClickHouse_Alter_Table_ReplacePartition_Replicas("1.0"))
 def partitioned_replicated_merge_tree_table(
-    self, table_name, partition_by, columns=None, order_by="tuple()"
+    self, table_name, partition_by, columns=None, order_by="tuple()", extra_columns=None
 ):
     """Create a ReplicatedMergeTree table partitioned by a specific column."""
     with By(
@@ -35,7 +34,37 @@ def partitioned_replicated_merge_tree_table(
         )
 
     with And("populating it with the data needed to create multiple partitions"):
-        create_partitions_with_random_uint64(table_name=table_name)
+        create_partitions_with_random_uint64(
+            table_name=table_name, extra_columns=extra_columns
+        )
+
+
+@TestStep(Given)
+def partitioned_collapsing_merge_tree_table(self, table_name, partition_by, **kwargs):
+    """Create a CollapsingMergeTree table with a dedicated sign column, so that the
+    partition column is free to hold the same partitions as the other engines."""
+    return create.partitioned_collapsing_merge_tree_table(
+        table_name=table_name,
+        partition_by=partition_by,
+        sign="Sign",
+        number_of_partitions=5,
+        **kwargs,
+    )
+
+
+@TestStep(Given)
+def partitioned_versioned_collapsing_merge_tree_table(
+    self, table_name, partition_by, **kwargs
+):
+    """Create a VersionedCollapsingMergeTree table with a dedicated sign column, so that
+    the partition column is free to hold the same partitions as the other engines."""
+    return create.partitioned_versioned_collapsing_merge_tree_table(
+        table_name=table_name,
+        partition_by=partition_by,
+        sign="Sign",
+        number_of_partitions=5,
+        **kwargs,
+    )
 
 
 def columns():
@@ -46,9 +75,16 @@ def columns():
         {"name": "Time", "type": "DateTime"},
         {"name": "Value", "type": "Float64"},
         {"name": "Timestamp", "type": "Int64"},
+        {"name": "Sign", "type": "Int8"},
     ]
 
     return partition_columns
+
+
+def extra_columns():
+    """Columns the insert must set explicitly: `Value` keeps SummingMergeTree from
+    dropping all-zero rows and `Sign` is required by the collapsing engines."""
+    return {"Value": "rand64()", "Sign": "if(rand() % 2 = 0, 1, -1)"}
 
 
 @TestCheck
@@ -70,12 +106,14 @@ def check_replace_partition(self, destination_table, source_table):
             partition_by="p",
             columns=columns(),
             order_by="i",
+            extra_columns=extra_columns(),
         )
         source_table(
             table_name=source_table_name,
             partition_by="p",
             columns=columns(),
             order_by="i",
+            extra_columns=extra_columns(),
         )
 
     with When("I replace partition from the source table to the destination table"):

--- a/alter/table/replace_partition/partition_types.py
+++ b/alter/table/replace_partition/partition_types.py
@@ -1,3 +1,4 @@
+from testflows.asserts import *
 from testflows.core import *
 
 from alter.table.replace_partition.common import (
@@ -122,17 +123,45 @@ def check_replace_partition(self, destination_table, source_table):
         destination_table(table_name=destination_table_name)
         source_table(table_name=source_table_name)
 
-    with When("I replace partition from the source table into the destination table"):
-        replace_partition(
-            destination_table=destination_table_name,
-            source_table=source_table_name,
-            partition=1,
+    source_partition_is_empty = source_table is partition_with_no_parts
+
+    if source_partition_is_empty and check_clickhouse_version(">=26.6")(self):
+        select_destination = (
+            f"SELECT i FROM {destination_table_name} WHERE p = 1 "
+            "ORDER BY tuple(*) FORMAT TabSeparated"
         )
 
-    with Then("I check that the partition on the destination table was replaced"):
-        check_partition_was_replaced(
-            destination_table=destination_table_name, source_table=source_table_name
-        )
+        with And("I save the data of the partition on the destination table"):
+            data_before = node.query(select_destination).output
+
+        with When(
+            "replace partition is refused because the source partition has no parts"
+        ):
+            replace_partition(
+                destination_table=destination_table_name,
+                source_table=source_table_name,
+                partition=1,
+                exitcode=36,
+                message="has no parts in partition",
+            )
+
+        with Then("I check that the data of the destination table is kept"):
+            assert node.query(select_destination).output == data_before, error()
+    else:
+        with When(
+            "I replace partition from the source table into the destination table"
+        ):
+            replace_partition(
+                destination_table=destination_table_name,
+                source_table=source_table_name,
+                partition=1,
+            )
+
+        with Then("I check that the partition on the destination table was replaced"):
+            check_partition_was_replaced(
+                destination_table=destination_table_name,
+                source_table=source_table_name,
+            )
 
 
 @TestSketch(Scenario)

--- a/alter/table/replace_partition/partition_types.py
+++ b/alter/table/replace_partition/partition_types.py
@@ -142,7 +142,7 @@ def check_replace_partition(self, destination_table, source_table):
                 source_table=source_table_name,
                 partition=1,
                 exitcode=36,
-                message="has no parts in partition",
+                message="DB::Exception: Source table",
             )
 
         with Then("I check that the data of the destination table is kept"):

--- a/helpers/create.py
+++ b/helpers/create.py
@@ -659,6 +659,7 @@ def partitioned_collapsing_merge_tree_table(
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
                 extra_columns=extra_columns,
+                partition_values=[-1, 1] if sign == partition_by else None,
             )
 
     return table_name
@@ -702,6 +703,7 @@ def partitioned_versioned_collapsing_merge_tree_table(
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
                 extra_columns=extra_columns,
+                partition_values=[-1, 1] if sign == partition_by else None,
             )
 
     return table_name

--- a/helpers/create.py
+++ b/helpers/create.py
@@ -1,9 +1,6 @@
 from testflows.core import *
 
-from alter.table.replace_partition.common import (
-    create_partitions_with_random_uint64,
-    create_partitions_for_collapsing_merge_tree,
-)
+from alter.table.replace_partition.common import create_partitions_with_random_uint64
 
 
 @TestStep(Given)
@@ -435,6 +432,7 @@ def partitioned_merge_tree_table(
     number_of_values=3,
     if_not_exists=False,
     query_settings=None,
+    extra_columns=None,
 ):
     """Create a MergeTree table partitioned by a specific column."""
     with By(f"creating a partitioned {table_name} table with a MergeTree engine"):
@@ -456,6 +454,7 @@ def partitioned_merge_tree_table(
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
                 number_of_values=number_of_values,
+                extra_columns=extra_columns,
             )
 
     return table_name
@@ -475,6 +474,7 @@ def partitioned_replicated_merge_tree_table(
     number_of_parts=10,
     query_settings=None,
     sharded=False,
+    extra_columns=None,
 ):
     """Create a ReplicatedMergeTree table partitioned by a specific column."""
     with By(
@@ -497,6 +497,7 @@ def partitioned_replicated_merge_tree_table(
                 table_name=table_name,
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
+                extra_columns=extra_columns,
             )
 
     return table_name
@@ -556,6 +557,7 @@ def partitioned_replacing_merge_tree_table(
     populate=True,
     number_of_partitions=5,
     number_of_parts=1,
+    extra_columns=None,
 ):
     """Create a ReplacingMergeTree table partitioned by a specific column."""
     with By(
@@ -576,6 +578,7 @@ def partitioned_replacing_merge_tree_table(
                 table_name=table_name,
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
+                extra_columns=extra_columns,
             )
 
     return table_name
@@ -593,12 +596,13 @@ def partitioned_summing_merge_tree_table(
     populate=True,
     number_of_partitions=5,
     number_of_parts=1,
+    extra_columns=None,
 ):
     """Create a SummingMergeTree table partitioned by a specific column."""
     with By(
         f"creating a partitioned {table_name} table with a SummingMergeTree engine"
     ):
-        create_aggregating_merge_tree_table(
+        create_summing_merge_tree_table(
             table_name=table_name,
             columns=columns,
             partition_by=partition_by,
@@ -613,6 +617,7 @@ def partitioned_summing_merge_tree_table(
                 table_name=table_name,
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
+                extra_columns=extra_columns,
             )
 
     return table_name
@@ -630,6 +635,8 @@ def partitioned_collapsing_merge_tree_table(
     populate=True,
     number_of_partitions=1,
     number_of_parts=1,
+    extra_columns=None,
+    sign="p",
 ):
     """Create a CollapsingMergeTree table partitioned by a specific column."""
     with By(
@@ -639,7 +646,7 @@ def partitioned_collapsing_merge_tree_table(
             table_name=table_name,
             columns=columns,
             partition_by=partition_by,
-            sign="p",
+            sign=sign,
             order_by=order_by,
             cluster=cluster,
             stop_merges=stop_merges,
@@ -647,10 +654,11 @@ def partitioned_collapsing_merge_tree_table(
 
     if populate:
         with And("populating it with the data needed to create multiple partitions"):
-            create_partitions_for_collapsing_merge_tree(
+            create_partitions_with_random_uint64(
                 table_name=table_name,
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
+                extra_columns=extra_columns,
             )
 
     return table_name
@@ -668,6 +676,9 @@ def partitioned_versioned_collapsing_merge_tree_table(
     populate=True,
     number_of_partitions=1,
     number_of_parts=1,
+    extra_columns=None,
+    sign="p",
+    version="i",
 ):
     """Create a VersionedCollapsingMergeTree table partitioned by a specific column."""
     with By(
@@ -677,8 +688,8 @@ def partitioned_versioned_collapsing_merge_tree_table(
             table_name=table_name,
             columns=columns,
             partition_by=partition_by,
-            sign="p",
-            version="i",
+            sign=sign,
+            version=version,
             order_by=order_by,
             cluster=cluster,
             stop_merges=stop_merges,
@@ -690,6 +701,7 @@ def partitioned_versioned_collapsing_merge_tree_table(
                 table_name=table_name,
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
+                extra_columns=extra_columns,
             )
 
     return table_name
@@ -707,12 +719,13 @@ def partitioned_aggregating_merge_tree_table(
     populate=True,
     number_of_partitions=5,
     number_of_parts=1,
+    extra_columns=None,
 ):
     """Create a AggregatingMergeTree table partitioned by a specific column."""
     with By(
         f"creating a partitioned {table_name} table with a AggregatingMergeTree engine"
     ):
-        create_summing_merge_tree_table(
+        create_aggregating_merge_tree_table(
             table_name=table_name,
             columns=columns,
             partition_by=partition_by,
@@ -727,6 +740,7 @@ def partitioned_aggregating_merge_tree_table(
                 table_name=table_name,
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
+                extra_columns=extra_columns,
             )
 
     return table_name
@@ -744,6 +758,7 @@ def partitioned_graphite_merge_tree_table(
     populate=True,
     number_of_partitions=5,
     number_of_parts=1,
+    extra_columns=None,
 ):
     """Create a GraphiteMergeTree table partitioned by a specific column."""
     with By(
@@ -765,6 +780,7 @@ def partitioned_graphite_merge_tree_table(
                 table_name=table_name,
                 number_of_partitions=number_of_partitions,
                 number_of_parts=number_of_parts,
+                extra_columns=extra_columns,
             )
 
     return table_name


### PR DESCRIPTION
Fix #160 

ClickHouse 26.6 refuses `REPLACE PARTITION` when the source has no parts in the requested partition. That broke 32 tests in `alter_replace` plus the `concurrent actions` scenario — and 26 of the 32 turned out to be tests that had been green while never replacing any data.

## Why they were green before

Every scenario validates with `check_partition_was_replaced`, which asserts:

```python
assert partition_values_destination == partition_values_source
```

Until 26.5, replacing from an empty source silently emptied the destination partition. The assertion then compared empty to empty and passed. It could not distinguish "replaced successfully" from "both are empty". The guard did not break these tests — it revealed they were not testing anything.

Upstream context: [ClickHouse#23727](https://github.com/ClickHouse/ClickHouse/issues/23727), open since 2021, classified the old behaviour as silent data loss. The previous behaviour is still available via `allow_replace_partition_from_empty_source = 1`.

## Changes

**1. `concurrent replace partitions` — off-by-one (13 failures)**

`for parts in range(1, number_of_parts)` with `number_of_parts = random.randrange(1, 50)` runs zero inserts when the draw is `1`, so ~2% of partitions were created with no parts at all. Measured in the failing run: 96 of 99 partitions created, and every partition that failed had zero inserts logged.

**2. `engines` with a `SummingMergeTree` source (8 failures)**

`SummingMergeTree` drops rows whose summing columns are all zero. The shared insert only fills `p` and `i`, which are the partition and sorting keys and therefore not summed, so every row was discarded and the source ended up completely empty. Verified on 26.6.2: `INSERT (p, i)` → 0 rows, `INSERT (p, i, Value)` → 3 rows.

This became visible when [#111](https://github.com/Altinity/clickhouse-regression/issues/111) moved these tables from `ORDER BY tuple()` to `ORDER BY i`, which took `i` out of the summing set. Same pattern as [#129](https://github.com/Altinity/clickhouse-regression/issues/129).

**3. `engines` with a `CollapsingMergeTree` source (5 failures)**

The helper reused the partition column as the sign column (`sign="p"`), which forced partitions to `{-1, 1}` and one partition per table. To keep signs valid, the population drew `random.choice([-1, 1])` as the partition value — so half the time the only partition was `-1` while the test replaces partition `1`. All 5 tables that drew `-1` failed; all 11 that drew `1` passed.

Collapsing engines now take a dedicated `Sign` column. This frees `p` to hold the same 5 partitions as every other engine, and the sign varies per row, which preserves the intent of the original change without randomising the partition. As a side effect, collapsing becomes structurally possible: with `sign="p"`, rows with opposite signs landed in different partitions and could never collapse.

The other callers of these wrappers keep the partition column *as* the sign, and unifying the population initially broke them: the shared helper inserts `p = 1..N`, so `p = 2` was rejected with `Code: 117. Incorrect data: Sign = 2 (must be 1 or -1)`. When the sign is the partition column, the population now picks the partition value from `[-1, 1]`, which makes the generated SQL byte-for-byte identical to the helper that was removed. Caught by a 26.3 run of `s3/export part`.

**4. `partition types` and `data integrity` — intentional empty-source tests (6 failures)**

These deliberately replace from a source with no parts (`ALTER TABLE ... DROP PARTITION 1`, or a partition beyond the source's range). They now expect the refusal on 26.6+ and assert that the destination data is kept; older versions keep the previous expectation.

The expectation is matched by the `DB::Exception: Source table` prefix. Matching only `has no parts in partition` was not enough: `query()` skips its generic "output has exception" check only when the expected message itself contains `Exception:`, so the test still failed on the very exception it was asserting.

For `data integrity` this also resolves a contradiction. The requirement it declares says:

> **RQ.SRS-032.ClickHouse.Alter.Table.ReplacePartition.NonExistentPartition** — "[ClickHouse] SHALL keep the data of the destination table when replacing partition form the non-existent partition of a source table."

The test asserted the opposite — that the destination was emptied. The new ClickHouse behaviour is what the requirement always asked for.

**5. Swapped engine wrappers**

`partitioned_summing_merge_tree_table` called `create_aggregating_merge_tree_table` and vice versa. Both engines were exercised, but under each other's names, so the reported engine in every combination involving them was wrong.

**6. `concurrent actions` — the partition to replace was drawn blindly**

The scenario deliberately destroys partitions (`DROP`, `DETACH`, `MOVE`) over 100 iterations, but drew `partition_to_replace` from `random.randrange(1, 500)` — the range the tables were *created* with, not the partitions that survived. Once a draw landed on a destroyed partition the guard fired, and the surrounding `retries(timeout=60)` could not recover: the draw sat outside the retry, so every attempt asked for the same partition, and that partition never comes back.

This is accumulated state, not a race. 128 of the 147 guard hits in the run were on partition 12, which iteration 2 had dropped 195s earlier.

The partition now comes from `system.parts` and is drawn inside the retry, so a partition removed by a concurrent action mid-attempt is simply reconsidered on the next attempt.

This corrects an earlier assessment in this PR that `concurrent actions` needed no change. That was based on a single job log which happened to be the one that passed — `replace partition along other actions` failed in 51 of the 53 results recorded in the CI database.

## Decisions

- `create_partitions_with_random_uint64` takes an optional `extra_columns`. With the default the generated SQL is byte-for-byte unchanged, so the ~41 other callers are unaffected.
- The collapsing wrappers keep `sign="p"` / `version="i"` as defaults, so the s3 and parquet callers keep the schema they had; only the engines test passes a dedicated sign column. Keeping the default was not enough on its own — see the note in change 3.
- We did not use `allow_replace_partition_from_empty_source = 1` anywhere. It would have turned everything green while leaving 26 tests asserting a behaviour upstream fixed as a data-loss bug.
- Two other blind draws in `concurrent_actions.py` were left alone on purpose. `replace_partition_with_single_concurrent_action` has the same flaw, but the feature only runs `one_replace_partition` and `replace_partition_along_other_actions`, so it is dead code. `replace_partition_from_another_table` draws blindly too, but from inside the action, so each retry re-draws and it self-heals — and none of the 147 guard hits name the destination table as the source, which is what those actions would use.

## Not covered

`RQ.SRS-032.ClickHouse.Alter.Table.ReplacePartition.Concurrent.Manipulating.Partitions.Drop` requires that `DROP PARTITION` waits for a `REPLACE PARTITION` on the same partition to finish. This suite cannot exercise it reliably: it needs two independent draws to pick the same partition (~1/500 per iteration) *and* to overlap in time. Covering it needs a dedicated test that forces the overlap. Tracked in #160.

## References

- Investigation issue: https://github.com/Altinity/clickhouse-regression/issues/160
- Failing CI run: https://github.com/Altinity/ClickHouse/actions/runs/31008527066/job/92685321160
- Full-suite run with these changes: https://github.com/Altinity/clickhouse-regression/actions/runs/31151708532
- 26.3 run that caught the collapsing regression: https://github.com/Altinity/clickhouse-regression/actions/runs/31202263970/job/92944853146
