### PR TITLE
Make --stress opt-in on the alter/stress workflow.

### DIFF
--- a/.github/workflows/run-alter-stress.yml
+++ b/.github/workflows/run-alter-stress.yml
@@ -102,6 +102,10 @@ on:
         description: "Extra test program arguments. Default: none (empty string)."
         type: string
         default: ""
+      stress:
+        description: "Pass --stress (unbounded combination count). Off = 20 groups per scenario."
+        type: boolean
+        default: false
       custom_run_name:
         description: '📝 Custom run name (optional)'
         required: false
@@ -128,7 +132,7 @@ env:
     --parallel ${{ vars.PARALLEL }}
     --attr project="${GITHUB_REPOSITORY}" project.id="${GITHUB_REPOSITORY_ID}" user.name="${GITHUB_ACTOR}" version="${{ inputs.version }}" package="${{ inputs.package }}" repository="https://github.com/Altinity/clickhouse-regression" commit.hash="$(git rev-parse HEAD)" job.name=$GITHUB_JOB job.retry=$GITHUB_RUN_ATTEMPT job.url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" arch="$(uname -i)" report.url=$SUITE_REPORT_INDEX_URL
     --log raw.log ${{ inputs.extra_args }}
-    --stress
+    ${{ inputs.stress && '--stress' || '' }}
     --only ":/simplified/*" ":/combinations/:/${{ inputs.scenario }}*"
   artifact_paths: |
     ./report.html


### PR DESCRIPTION
Unbounded combinations OOM CX53 runners; the default 20-group run is the CI gate.